### PR TITLE
Reduce the potential for Zonky token timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,25 +21,11 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
+before_install:
+  - sudo apt-get -qq update
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module
   - mvn --batch-mode -pl $MODULE install -Dassembly.skipAssembly -Dgpg.skip
 matrix: # fail all if one fails
   fast_finish: true
-  include:
-    - jdk: openjdk9
-      os: linux
-      before_script:
-        - jdk_switcher use oraclejdk9
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java9-installer
-    - jdk: openjdk8
-      before_script:
-        - jdk_switcher use oraclejdk8
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - sudo apt-get -qq update
+  - sudo apt-get -qq update && apt-get --qq upgrade *java* *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,8 @@ env:
   global:
     - JAVA_OPTS=-Xmx2g
     - MAVEN_OPTS=$JAVA_OPTS
-addons: # make sure we're using the latest Java as Travis default is quite old
-  apt:
-    packages:
-      - oracle-java8-installer
-      - oracle-java9-installer
-os:
-  - linux
-env: # execution per-module so that PITest doesn't timeout the build, most difficult modules first
+env:
+  # execution per-module so that PITest doesn't timeout the build, most difficult modules first
   - MODULE=robozonky-app
   - MODULE=robozonky-installer
   - MODULE=robozonky-notifications
@@ -19,11 +13,8 @@ env: # execution per-module so that PITest doesn't timeout the build, most diffi
   - MODULE=robozonky-common
   - MODULE=robozonky-api
   - MODULE=robozonky-distribution/robozonky-distribution-full,robozonky-distribution/robozonky-distribution-installer
-jdk:
-  - oraclejdk8
-  - oraclejdk9
-matrix: # fail all if one fails
-  fast_finish: true
+os:
+  - linux
 cache:
   directories:
   - $HOME/.m2
@@ -31,3 +22,20 @@ install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module
   - mvn --batch-mode -pl $MODULE install -Dassembly.skipAssembly -Dgpg.skip
+matrix: # fail all if one fails
+  fast_finish: true
+  include:
+    - jdk: oraclejdk9
+      before_script:
+        - jdk_switcher use oraclejdk9
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java9-installer
+    - jdk: oraclejdk8
+      before_script:
+        - jdk_switcher use oraclejdk8
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - sudo apt-get -qq update && sudo apt-get upgrade *java* *jdk*
+  - sudo apt-get -qq update && sudo apt-get upgrade *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - sudo apt-get -qq update && apt-get sudo upgrade *java* *jdk*
+  - sudo apt-get -qq update && sudo apt-get upgrade *java* *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - sudo apt-get -qq update && apt-get --qq upgrade *java* *jdk*
+  - sudo apt-get -qq update && apt-get upgrade *java* *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,7 @@ os:
   - linux
 jdk:
   - oraclejdk9
-      before_script:
-        - jdk_switcher use oraclejdk9
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java9-installer
   - oraclejdk8
-      before_script:
-        - jdk_switcher use oraclejdk8
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java8-installer
 cache:
   directories:
   - $HOME/.m2
@@ -39,3 +27,19 @@ script: # test the one module
   - mvn --batch-mode -pl $MODULE install -Dassembly.skipAssembly -Dgpg.skip
 matrix: # fail all if one fails
   fast_finish: true
+  include:
+    - jdk: openjdk9
+      os: linux
+      before_script:
+        - jdk_switcher use oraclejdk9
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java9-installer
+    - jdk: openjdk8
+      before_script:
+        - jdk_switcher use oraclejdk8
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-before_install:
-  - sudo apt-get -qq update && sudo apt-get upgrade *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - sudo apt-get -qq update && apt-get upgrade *java* *jdk*
+  - sudo apt-get -qq update && apt-get sudo upgrade *java* *jdk*
 install: # build all required modules for the given module, no tests
   - mvn --batch-mode -pl $MODULE -am install -DskipTests -Dgpg.skip
 script: # test the one module

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,21 @@ env:
   - MODULE=robozonky-distribution/robozonky-distribution-full,robozonky-distribution/robozonky-distribution-installer
 os:
   - linux
+jdk:
+  - oraclejdk9
+      before_script:
+        - jdk_switcher use oraclejdk9
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java9-installer
+  - oraclejdk8
+      before_script:
+        - jdk_switcher use oraclejdk8
+      addons: # make sure we're using the latest Java as Travis default is quite old
+        apt:
+          packages:
+            - oracle-java8-installer
 cache:
   directories:
   - $HOME/.m2
@@ -24,18 +39,3 @@ script: # test the one module
   - mvn --batch-mode -pl $MODULE install -Dassembly.skipAssembly -Dgpg.skip
 matrix: # fail all if one fails
   fast_finish: true
-  include:
-    - jdk: oraclejdk9
-      before_script:
-        - jdk_switcher use oraclejdk9
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java9-installer
-    - jdk: oraclejdk8
-      before_script:
-        - jdk_switcher use oraclejdk8
-      addons: # make sure we're using the latest Java as Travis default is quite old
-        apt:
-          packages:
-            - oracle-java8-installer

--- a/robozonky-app/src/main/java/com/github/robozonky/app/authentication/PasswordBasedAccess.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/authentication/PasswordBasedAccess.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.app.authentication;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.github.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.robozonky.api.remote.entities.ZonkyApiToken;
@@ -51,7 +52,8 @@ class PasswordBasedAccess extends AbstractAuthenticated {
 
     @Override
     public <T> T call(final Function<Zonky, T> op) {
-        final ZonkyApiToken token = PasswordBasedAccess.trigger(apis, secrets.getUsername(), secrets.getPassword());
+        final Supplier<ZonkyApiToken> token =
+                () -> PasswordBasedAccess.trigger(apis, secrets.getUsername(), secrets.getPassword());
         return apis.authenticated(token, (zonky) -> {
             try {
                 return op.apply(zonky);

--- a/robozonky-app/src/main/java/com/github/robozonky/app/authentication/TokenBasedAccess.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/authentication/TokenBasedAccess.java
@@ -46,7 +46,7 @@ class TokenBasedAccess extends AbstractAuthenticated {
 
     @Override
     public <T> T call(final Function<Zonky, T> operation) {
-        return apis.authenticated(getToken(), operation);
+        return apis.authenticated(this::getToken, operation);
     }
 
     @Override

--- a/robozonky-app/src/test/java/com/github/robozonky/app/authentication/AuthenticatedTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/authentication/AuthenticatedTest.java
@@ -46,11 +46,10 @@ class AuthenticatedTest extends AbstractZonkyLeveragingTest {
             final Function f = i.getArgument(0);
             return f.apply(oauth);
         });
-        when(api.authenticated(any(ZonkyApiToken.class), any(Function.class)))
-                .then(i -> {
-                    final Function f = i.getArgument(1);
-                    return f.apply(z);
-                });
+        when(api.authenticated(any(), any(Function.class))).then(i -> {
+            final Function f = i.getArgument(1);
+            return f.apply(z);
+        });
         return api;
     }
 

--- a/robozonky-app/src/test/java/com/github/robozonky/app/authentication/AuthenticatedTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/authentication/AuthenticatedTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.github.robozonky.api.remote.entities.RawInvestment;
 import com.github.robozonky.api.remote.entities.Restrictions;
@@ -47,6 +48,8 @@ class AuthenticatedTest extends AbstractZonkyLeveragingTest {
             return f.apply(oauth);
         });
         when(api.authenticated(any(), any(Function.class))).then(i -> {
+            final Supplier<ZonkyApiToken> s = i.getArgument(0);
+            s.get();
             final Function f = i.getArgument(1);
             return f.apply(z);
         });

--- a/robozonky-common/src/main/java/com/github/robozonky/common/remote/ApiProvider.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/common/remote/ApiProvider.java
@@ -19,6 +19,7 @@ package com.github.robozonky.common.remote;
 import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.github.robozonky.api.remote.CollectionsApi;
 import com.github.robozonky.api.remote.ControlApi;
@@ -71,12 +72,12 @@ public class ApiProvider implements AutoCloseable {
      * Instantiate an API as a RESTEasy client proxy.
      * @param api RESTEasy endpoint.
      * @param url URL to the web API represented by the endpoint.
-     * @param token OAuth token to authenticate with.
+     * @param token Supplies a valid OAuth token to authenticate with.
      * @param <T> API type.
      * @return RESTEasy client proxy for the API, ready to be called.
      */
     protected <S, T> PaginatedApi<S, T> obtainPaginated(final Class<T> api, final String url,
-                                                        final ZonkyApiToken token) {
+                                                        final Supplier<ZonkyApiToken> token) {
         return new PaginatedApi<>(api, url, token, client);
     }
 
@@ -111,16 +112,16 @@ public class ApiProvider implements AutoCloseable {
         return this.marketplace(LoanApi.class, ApiProvider.ZONKY_URL);
     }
 
-    private Zonky authenticated(final ZonkyApiToken token) {
+    private Zonky authenticated(final Supplier<ZonkyApiToken> token) {
         return new Zonky(this.control(token), this.marketplace(token), this.secondaryMarketplace(token),
                          this.portfolio(token), this.wallet(token), this.collections(token));
     }
 
-    public void authenticated(final ZonkyApiToken token, final Consumer<Zonky> operation) {
+    public void authenticated(final Supplier<ZonkyApiToken> token, final Consumer<Zonky> operation) {
         authenticated(token, toFunction(operation));
     }
 
-    public <T> T authenticated(final ZonkyApiToken token, final Function<Zonky, T> operation) {
+    public <T> T authenticated(final Supplier<ZonkyApiToken> token, final Function<Zonky, T> operation) {
         return operation.apply(authenticated(token));
     }
 
@@ -129,7 +130,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private PaginatedApi<RawLoan, LoanApi> marketplace(final ZonkyApiToken token) {
+    private PaginatedApi<RawLoan, LoanApi> marketplace(final Supplier<ZonkyApiToken> token) {
         return this.obtainPaginated(LoanApi.class, ApiProvider.ZONKY_URL, token);
     }
 
@@ -138,7 +139,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private PaginatedApi<Participation, ParticipationApi> secondaryMarketplace(final ZonkyApiToken token) {
+    private PaginatedApi<Participation, ParticipationApi> secondaryMarketplace(final Supplier<ZonkyApiToken> token) {
         return this.obtainPaginated(ParticipationApi.class, ApiProvider.ZONKY_URL, token);
     }
 
@@ -147,7 +148,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private PaginatedApi<BlockedAmount, WalletApi> wallet(final ZonkyApiToken token) {
+    private PaginatedApi<BlockedAmount, WalletApi> wallet(final Supplier<ZonkyApiToken> token) {
         return this.obtainPaginated(WalletApi.class, ApiProvider.ZONKY_URL, token);
     }
 
@@ -156,7 +157,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private PaginatedApi<RawInvestment, PortfolioApi> portfolio(final ZonkyApiToken token) {
+    private PaginatedApi<RawInvestment, PortfolioApi> portfolio(final Supplier<ZonkyApiToken> token) {
         return this.obtainPaginated(PortfolioApi.class, ApiProvider.ZONKY_URL, token);
     }
 
@@ -165,7 +166,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private Api<ControlApi> control(final ZonkyApiToken token) {
+    private Api<ControlApi> control(final Supplier<ZonkyApiToken> token) {
         final ControlApi proxy = ProxyFactory.newProxy(client, new AuthenticatedFilter(token), ControlApi.class,
                                                        ApiProvider.ZONKY_URL);
         return new Api<>(proxy);
@@ -176,7 +177,7 @@ public class ApiProvider implements AutoCloseable {
      * @param token The Zonky API token, representing an control user.
      * @return New API instance.
      */
-    private PaginatedApi<RawDevelopment, CollectionsApi> collections(final ZonkyApiToken token) {
+    private PaginatedApi<RawDevelopment, CollectionsApi> collections(final Supplier<ZonkyApiToken> token) {
         return this.obtainPaginated(CollectionsApi.class, ApiProvider.ZONKY_URL, token);
     }
 

--- a/robozonky-common/src/main/java/com/github/robozonky/common/remote/ApiProvider.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/common/remote/ApiProvider.java
@@ -72,7 +72,7 @@ public class ApiProvider implements AutoCloseable {
      * Instantiate an API as a RESTEasy client proxy.
      * @param api RESTEasy endpoint.
      * @param url URL to the web API represented by the endpoint.
-     * @param token Supplies a valid OAuth token to authenticate with.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @param <T> API type.
      * @return RESTEasy client proxy for the API, ready to be called.
      */
@@ -127,7 +127,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky loan API which requires authentication.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private PaginatedApi<RawLoan, LoanApi> marketplace(final Supplier<ZonkyApiToken> token) {
@@ -136,7 +136,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky participation API which requires authentication.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private PaginatedApi<Participation, ParticipationApi> secondaryMarketplace(final Supplier<ZonkyApiToken> token) {
@@ -145,7 +145,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky wallet API which requires authentication.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private PaginatedApi<BlockedAmount, WalletApi> wallet(final Supplier<ZonkyApiToken> token) {
@@ -154,7 +154,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky portfolio API which requires authentication.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private PaginatedApi<RawInvestment, PortfolioApi> portfolio(final Supplier<ZonkyApiToken> token) {
@@ -163,7 +163,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky control API which requires authentication.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private Api<ControlApi> control(final Supplier<ZonkyApiToken> token) {
@@ -174,7 +174,7 @@ public class ApiProvider implements AutoCloseable {
 
     /**
      * Retrieve user-specific Zonky API which provides information on loan collections.
-     * @param token The Zonky API token, representing an control user.
+     * @param token Supplier of a valid Zonky API token, always representing the active user.
      * @return New API instance.
      */
     private PaginatedApi<RawDevelopment, CollectionsApi> collections(final Supplier<ZonkyApiToken> token) {

--- a/robozonky-common/src/main/java/com/github/robozonky/common/remote/AuthenticatedFilter.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/common/remote/AuthenticatedFilter.java
@@ -16,15 +16,26 @@
 
 package com.github.robozonky.common.remote;
 
+import java.util.function.Supplier;
+import javax.ws.rs.client.ClientRequestContext;
+
 import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 
 class AuthenticatedFilter extends RoboZonkyFilter {
 
     private static final char[] EMPTY_TOKEN = new char[0];
+    private final Supplier<ZonkyApiToken> token;
 
-    public AuthenticatedFilter(final ZonkyApiToken token) {
+    public AuthenticatedFilter(final Supplier<ZonkyApiToken> token) {
         // null token = no token
-        final char[] t = token == null ? AuthenticatedFilter.EMPTY_TOKEN : token.getAccessToken();
+        this.token = token;
+    }
+
+    @Override
+    public void filter(ClientRequestContext clientRequestContext) {
+        final ZonkyApiToken supplied = token == null ? null : token.get();
+        final char[] t = supplied == null ? AuthenticatedFilter.EMPTY_TOKEN : supplied.getAccessToken();
         this.setRequestHeader("Authorization", "Bearer " + String.valueOf(t));
+        super.filter(clientRequestContext);
     }
 }

--- a/robozonky-common/src/main/java/com/github/robozonky/common/remote/PaginatedApi.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/common/remote/PaginatedApi.java
@@ -18,6 +18,7 @@ package com.github.robozonky.common.remote;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
@@ -33,7 +34,8 @@ class PaginatedApi<S, T> {
     private final String url;
     private final ResteasyClient client;
 
-    PaginatedApi(final Class<T> api, final String url, final ZonkyApiToken token, final ResteasyClient client) {
+    PaginatedApi(final Class<T> api, final String url, final Supplier<ZonkyApiToken> token,
+                 final ResteasyClient client) {
         this.api = api;
         this.url = url;
         this.client = client;

--- a/robozonky-common/src/test/java/com/github/robozonky/common/remote/ApiProviderTest.java
+++ b/robozonky-common/src/test/java/com/github/robozonky/common/remote/ApiProviderTest.java
@@ -48,7 +48,7 @@ class ApiProviderTest {
     void authenticatedProperlyClosed() {
         final ApiProvider p = spy(new ApiProvider());
         try (final ApiProvider provider = p) {
-            final Zonky result = provider.authenticated(mockToken(), Function.identity());
+            final Zonky result = provider.authenticated(ApiProviderTest::mockToken, Function.identity());
             assertThat(result).isNotNull();
         }
         verify(p).close();

--- a/robozonky-common/src/test/java/com/github/robozonky/common/remote/AuthenticatedFilterTest.java
+++ b/robozonky-common/src/test/java/com/github/robozonky/common/remote/AuthenticatedFilterTest.java
@@ -49,7 +49,7 @@ class AuthenticatedFilterTest extends AbstractCommonFilterTest {
 
     @Override
     protected RoboZonkyFilter getTestedFilter() {
-        return new AuthenticatedFilter(AuthenticatedFilterTest.TOKEN);
+        return new AuthenticatedFilter(() -> AuthenticatedFilterTest.TOKEN);
     }
 
     @Test
@@ -73,7 +73,7 @@ class AuthenticatedFilterTest extends AbstractCommonFilterTest {
         when(ctx2.getEntityStream()).thenReturn(c(token));
         when(ctx2.getStatusInfo()).thenReturn(Response.Status.fromStatusCode(expectedCode));
         when(ctx2.getStatus()).thenReturn(expectedCode);
-        final RoboZonkyFilter filter = new AuthenticatedFilter(token);
+        final RoboZonkyFilter filter = new AuthenticatedFilter(() -> token);
         filter.filter(ctx, ctx2);
         verify(ctx2, times(1)).setStatus(401);
     }

--- a/robozonky-installer/src/main/java/com/github/robozonky/installer/ZonkySettingsValidator.java
+++ b/robozonky-installer/src/main/java/com/github/robozonky/installer/ZonkySettingsValidator.java
@@ -20,9 +20,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import javax.ws.rs.ServerErrorException;
 
-import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import com.github.robozonky.common.remote.ApiProvider;
-import com.github.robozonky.common.remote.Zonky;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.installer.DataValidator;
 
@@ -52,10 +50,13 @@ public class ZonkySettingsValidator extends AbstractValidator {
         final ApiProvider p = apiSupplier.get();
         return p.oauth((oauth) -> {
             try {
-                LOGGER.info("Logging in.");
-                final ZonkyApiToken token = oauth.login(username, password.toCharArray());
-                LOGGER.info("Logging out.");
-                p.authenticated(token, Zonky::logout);
+                p.authenticated(() -> {
+                    LOGGER.info("Logging in.");
+                    return oauth.login(username, password.toCharArray());
+                }, zonky -> {
+                    LOGGER.info("Logging out.");
+                    zonky.logout();
+                });
                 return DataValidator.Status.OK;
             } catch (final ServerErrorException t) {
                 LOGGER.log(Level.SEVERE, "Failed accessing Zonky.", t);

--- a/robozonky-installer/src/test/java/com/github/robozonky/installer/ZonkySettingsValidatorTest.java
+++ b/robozonky-installer/src/test/java/com/github/robozonky/installer/ZonkySettingsValidatorTest.java
@@ -19,6 +19,7 @@ package com.github.robozonky.installer;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 
@@ -38,10 +39,6 @@ class ZonkySettingsValidatorTest {
 
     private static final String USERNAME = "someone@somewhere.cz", PASSWORD = UUID.randomUUID().toString();
 
-    private static ZonkyApiToken mockToken(final ZonkyApiToken token) {
-        return token == null ? any() : eq(token);
-    }
-
     private static ApiProvider mockApiProvider(final OAuth oauth, final ZonkyApiToken token, final Zonky zonky) {
         final ApiProvider api = mock(ApiProvider.class);
         when(api.oauth(any(Function.class))).then(i -> {
@@ -49,19 +46,19 @@ class ZonkySettingsValidatorTest {
             return f.apply(oauth);
         });
         doAnswer(i -> {
+            final Supplier t = i.getArgument(0);
+            assertThat(t.get()).isEqualTo(token);
             final Function f = i.getArgument(1);
             return f.apply(zonky);
-        }).when(api).authenticated(mockToken(token), any(Function.class));
+        }).when(api).authenticated(any(), any(Function.class));
         doAnswer(i -> {
+            final Supplier t = i.getArgument(0);
+            assertThat(t.get()).isEqualTo(token);
             final Consumer f = i.getArgument(1);
             f.accept(zonky);
             return null;
-        }).when(api).authenticated(mockToken(token), any(Consumer.class));
+        }).when(api).authenticated(any(), any(Consumer.class));
         return api;
-    }
-
-    static ApiProvider mockApiProvider() {
-        return mockApiProvider(mock(OAuth.class));
     }
 
     private static ApiProvider mockApiProvider(final OAuth oAuth) {


### PR DESCRIPTION
For some paginated reports, such as investment retrieval, the OAuth token was previously only ever requested before the first page. If the retrieval of pages took a long time, the token would expire in the meantime and the operation would always fail.

Therefore we refactor the code so that there is the option to refresh the token before every single Zonky API call. Rate limiting will be no match for us! :-)