### PR TITLE
Implement HTML notifications (closes #247)

### DIFF
--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/AbstractTargetHandler.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/AbstractTargetHandler.java
@@ -95,16 +95,16 @@ public abstract class AbstractTargetHandler {
     }
 
     public void send(final SupportedListener listener, final SessionInfo sessionInfo, final String subject,
-                     final String message) throws Exception {
+                     final String message, final String fallbackMessage) throws Exception {
         if (!shouldNotify(listener, sessionInfo)) {
             LOGGER.debug("Will not notify.");
             return;
         }
-        actuallySend(sessionInfo, subject, message);
+        actuallySend(sessionInfo, subject, message, fallbackMessage);
         getSpecificCounter(listener).increase(sessionInfo);
         notifications.increase(sessionInfo);
     }
 
     public abstract void actuallySend(final SessionInfo sessionInfo, final String subject,
-                                      final String message) throws Exception;
+                                      final String message, final String fallbackMessage) throws Exception;
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/AbstractTargetHandler.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/AbstractTargetHandler.java
@@ -94,17 +94,19 @@ public abstract class AbstractTargetHandler {
         }
     }
 
-    public void send(final SupportedListener listener, final SessionInfo sessionInfo, final String subject,
-                     final String message, final String fallbackMessage) throws Exception {
-        if (!shouldNotify(listener, sessionInfo)) {
+    public void offer(final Submission s) throws Exception {
+        final SupportedListener listener = s.getSupportedListener();
+        final SessionInfo session = s.getSessionInfo();
+        if (!shouldNotify(listener, session)) {
             LOGGER.debug("Will not notify.");
             return;
         }
-        actuallySend(sessionInfo, subject, message, fallbackMessage);
-        getSpecificCounter(listener).increase(sessionInfo);
-        notifications.increase(sessionInfo);
+        final Map<String, Object> data = s.getData();
+        send(session, s.getSubject(), s.getMessage(data), s.getFallbackMessage(data));
+        getSpecificCounter(listener).increase(session);
+        notifications.increase(session);
     }
 
-    public abstract void actuallySend(final SessionInfo sessionInfo, final String subject,
-                                      final String message, final String fallbackMessage) throws Exception;
+    public abstract void send(final SessionInfo sessionInfo, final String subject,
+                              final String message, final String fallbackMessage) throws Exception;
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/EmailHandler.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/EmailHandler.java
@@ -18,9 +18,8 @@ package com.github.robozonky.notifications;
 
 import com.github.robozonky.api.SessionInfo;
 import com.github.robozonky.internal.api.Defaults;
-import org.apache.commons.mail.Email;
 import org.apache.commons.mail.EmailException;
-import org.apache.commons.mail.SimpleEmail;
+import org.apache.commons.mail.HtmlEmail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +67,8 @@ final class EmailHandler extends AbstractTargetHandler {
         return config.readInt(target, "smtp.port", 25);
     }
 
-    private Email createNewEmail(final SessionInfo session) throws EmailException {
-        final Email email = new SimpleEmail();
+    private HtmlEmail createNewEmail(final SessionInfo session) throws EmailException {
+        final HtmlEmail email = new HtmlEmail();
         email.setCharset(Defaults.CHARSET.displayName());
         email.setHostName(getSmtpHostname());
         email.setSmtpPort(getSmtpPort());
@@ -90,10 +89,11 @@ final class EmailHandler extends AbstractTargetHandler {
 
     @Override
     public void actuallySend(final SessionInfo sessionInfo, final String subject,
-                             final String message) throws Exception {
-        final Email email = createNewEmail(sessionInfo);
+                             final String message, final String fallbackMessage) throws Exception {
+        final HtmlEmail email = createNewEmail(sessionInfo);
         email.setSubject(subject);
-        email.setMsg(message);
+        email.setHtmlMsg(message);
+        email.setTextMsg(fallbackMessage);
         LOGGER.debug("Will send '{}' from {} to {} through {}:{} as {}.", email.getSubject(),
                      email.getFromAddress(), email.getToAddresses(), email.getHostName(), email.getSmtpPort(),
                      getSmtpUsername());

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/EmailHandler.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/EmailHandler.java
@@ -88,8 +88,8 @@ final class EmailHandler extends AbstractTargetHandler {
     }
 
     @Override
-    public void actuallySend(final SessionInfo sessionInfo, final String subject,
-                             final String message, final String fallbackMessage) throws Exception {
+    public void send(final SessionInfo sessionInfo, final String subject,
+                     final String message, final String fallbackMessage) throws Exception {
         final HtmlEmail email = createNewEmail(sessionInfo);
         email.setSubject(subject);
         email.setHtmlMsg(message);

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/Submission.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/Submission.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.notifications;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.github.robozonky.api.SessionInfo;
+import freemarker.template.TemplateException;
+
+/**
+ * The point of this interface is to serve as the data transfer vehicle between the listener and the handler. All the
+ * heavy lifting, such as message creation from the templates, will only happen in the handler, when we're 100 % sure
+ * that the message will be sent and therefore the processing effort won't be in vain.
+ */
+public interface Submission {
+
+    SessionInfo getSessionInfo();
+
+    SupportedListener getSupportedListener();
+
+    Map<String, Object> getData();
+
+    String getSubject();
+
+    String getMessage(final Map<String, Object> data) throws IOException, TemplateException;
+
+    String getFallbackMessage(final Map<String, Object> data) throws IOException, TemplateException;
+}

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/AbstractListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/AbstractListener.java
@@ -16,6 +16,7 @@
 
 package com.github.robozonky.notifications.listeners;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,8 +35,10 @@ import com.github.robozonky.api.strategies.PortfolioOverview;
 import com.github.robozonky.internal.api.Defaults;
 import com.github.robozonky.internal.util.Maps;
 import com.github.robozonky.notifications.AbstractTargetHandler;
+import com.github.robozonky.notifications.Submission;
 import com.github.robozonky.notifications.SupportedListener;
 import com.github.robozonky.notifications.templates.TemplateProcessor;
+import freemarker.template.TemplateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,21 +114,56 @@ abstract class AbstractListener<T extends Event> implements EventListener<T> {
         return Collections.unmodifiableMap(result);
     }
 
+    private Submission createSubmission(final T event, final SessionInfo sessionInfo) {
+        final String s = this.getSubject(event);
+        final String t = this.getTemplateFileName();
+        return new Submission() {
+
+            @Override
+            public SessionInfo getSessionInfo() {
+                return sessionInfo;
+            }
+
+            @Override
+            public SupportedListener getSupportedListener() {
+                return listener;
+            }
+
+            @Override
+            public Map<String, Object> getData() {
+                final Map<String, Object> data =
+                        new HashMap<>(AbstractListener.this.getData(event, sessionInfo));
+                data.put("subject", getSubject());
+                return Collections.unmodifiableMap(data);
+            }
+
+            @Override
+            public String getSubject() {
+                return s;
+            }
+
+            @Override
+            public String getMessage(final Map<String, Object> data) throws IOException, TemplateException {
+                return TemplateProcessor.INSTANCE.processHtml(t, data);
+            }
+
+            @Override
+            public String getFallbackMessage(final Map<String, Object> data) throws IOException,
+                    TemplateException {
+                return TemplateProcessor.INSTANCE.processPlainText(t, data);
+            }
+        };
+    }
+
     @Override
     final public void handle(final T event, final SessionInfo sessionInfo) {
         try {
             if (!this.shouldNotify(event, sessionInfo)) {
                 LOGGER.debug("Will not notify.");
             } else {
+                // only do the heavy lifting in the handler, after the final send/no-send decision was made
                 LOGGER.debug("Notifying {}.", event);
-                final String subject = getSubject(event);
-                final Map<String, Object> data = new HashMap<>(this.getData(event, sessionInfo));
-                data.put("subject", subject);
-                final Map<String, Object> result = Collections.unmodifiableMap(data);
-                final String message = TemplateProcessor.INSTANCE.processHtml(this.getTemplateFileName(), result);
-                final String fallbackMessage = TemplateProcessor.INSTANCE.processPlainText(this.getTemplateFileName(),
-                                                                                           result);
-                handler.send(listener, sessionInfo, subject, message, fallbackMessage);
+                handler.offer(createSubmission(event, sessionInfo));
             }
         } catch (final Exception ex) {
             throw new IllegalStateException("Event processing failed.", ex);

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/AbstractListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/AbstractListener.java
@@ -118,9 +118,14 @@ abstract class AbstractListener<T extends Event> implements EventListener<T> {
                 LOGGER.debug("Will not notify.");
             } else {
                 LOGGER.debug("Notifying {}.", event);
-                final String message = TemplateProcessor.INSTANCE.process(this.getTemplateFileName(),
-                                                                          this.getData(event, sessionInfo));
-                handler.send(listener, sessionInfo, getSubject(event), message);
+                final String subject = getSubject(event);
+                final Map<String, Object> data = new HashMap<>(this.getData(event, sessionInfo));
+                data.put("subject", subject);
+                final Map<String, Object> result = Collections.unmodifiableMap(data);
+                final String message = TemplateProcessor.INSTANCE.processHtml(this.getTemplateFileName(), result);
+                final String fallbackMessage = TemplateProcessor.INSTANCE.processPlainText(this.getTemplateFileName(),
+                                                                                           result);
+                handler.send(listener, sessionInfo, subject, message, fallbackMessage);
             }
         } catch (final Exception ex) {
             throw new IllegalStateException("Event processing failed.", ex);

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/templates/html/HtmlTemplate.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/templates/html/HtmlTemplate.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.notifications.templates.html;
+
+public enum HtmlTemplate {
+
+    INSTANCE;
+
+}

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-collections-info.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-collections-info.ftl
@@ -1,0 +1,24 @@
+<#assign items=data.collections>
+<#if items?size == 0>
+    <p>Oddělení vymáhání Zonky nedodalo žádné informace.</p>
+<#else>
+    <table>
+        <caption>Poslední informace z oddělení vymáhání Zonky</caption>
+        <thead>
+        <tr>
+            <th>Časová známka</th>
+            <th>Událost</th>
+            <th>Poznámka</th>
+        </tr>
+        </thead>
+        <tbody>
+            <#list items as x>
+              <tr>
+                <td><#if x.endDate??>${x.startDate?date} až ${x.endDate?date}<#else>${x.startDate?date}</#if></td>
+                <td>${x.code}</td>
+                <td>${x.note}</td>
+              </tr>
+            </#list>
+        </tbody>
+    </table>
+</#if>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-loan-info.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-loan-info.ftl
@@ -1,0 +1,17 @@
+<table>
+  <caption>Dodatečné informace o půjčce</caption>
+  <tbody>
+    <tr>
+      <th>Účel:</th>
+      <td>${data.loanPurpose.getCode()?cap_first}</td>
+    </tr>
+    <tr>
+      <th>Kraj:</th>
+      <td>${data.loanRegion.getCode()?cap_first}</td>
+    </tr>
+    <tr>
+      <th>Zdroj příjmů:</th>
+      <td>${data.loanMainIncomeType.getCode()?cap_first}</td>
+    </tr>
+  </tbody>
+</table>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-portfolio-info.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/additional-portfolio-info.ftl
@@ -1,0 +1,35 @@
+<p>Nový zůstatek na Zonky účtu je ${data.portfolio.balance?string.currency}.</p>
+
+<table>
+  <caption>Aktuální struktura portfolia</caption>
+  <thead>
+    <tr>
+        <th>Rating</th>
+        <th colspan="2">Investováno</th>
+        <th colspan="2">Ohroženo</th>
+    </tr>
+  </thead>
+  <tfoot>
+    <th>Celkem</th>
+    <th colspan="2">${data.portfolio.total?string.currency}</th>
+    <th>${data.portfolio.totalRisk?string.currency}</th>
+    <th>${data.portfolio.totalShare?string.@interest}</th>
+  </tfoot>
+  <tbody>
+    <#list data.ratings as rating>
+      <tr>
+        <#assign code = rating.getCode()>
+        <#assign abs = data.portfolio.absoluteShare[code]>
+        <#assign rel = data.portfolio.relativeShare[code]>
+        <#assign absRisk = data.portfolio.absoluteRisk[code]>
+        <#assign relRisk = data.portfolio.relativeRisk[code]>
+        <td>${code}</td>
+        <td>${abs?string.currency}</td>
+        <td>(${rel?string.@interest})</td>
+        <td>${absRisk?string.currency}</td>
+        <td>(${relRisk?string.@interest})</td>
+      </tr>
+    </#list>
+  </tbody>
+</table>
+

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/core.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/core.ftl
@@ -8,14 +8,9 @@
 
 <body>
     <header>
-        <#if data.session.isDryRun>
-           <p>
-                <strong><em>RoboZonky</em> běží ve zkušebním režimu. Následující informace slouží jen pro demonstraci
-                nastavení strategie a nejsou platné!</strong>
-            </p>
-        </#if>
-        <p><em>RoboZonky</em> pro <em>Zonky</em> účet <em>${data.session.userName}</em> Vás tímto informuje o
-            následující operaci:</p>
+        <p><small><em>RoboZonky</em> pro <em>Zonky</em> účet <em>${data.session.userName}</em> Vás tímto informuje o
+            následující skutečnosti:</small></p>
+        <hr>
     </header>
 
     <main>
@@ -23,12 +18,23 @@
     </main>
 
     <footer>
-      <p>Tuto zprávu dostáváte, protože je tak Váš robot nakonfigurován. Neodpovídejte na ni.</p>
-      <p>Všechna data v této zprávě jsou pouze informativního charakteru. Jediné směrodatné údaje poskytuje
-        <em>Zonky</em> dashboard.</p>
-      <p>Dotazy k <em>RoboZonky</em> pokládejte v
-        <a href="https://groups.google.com/forum/#!forum/robozonky-users">uživatelské skupině</a></p>
-      <p>Vygeneroval <em>${data.session.userAgent}</em> dne ${timestamp?date} v ${timestamp?time}.</p>
+      <hr>
+      <ul>
+        <li><small>Tuto zprávu dostáváte, protože je tak Váš robot nakonfigurován. Neodpovídejte na ni.</small></li>
+        <#if data.session.isDryRun>
+           <li>
+                <small><em>RoboZonky</em> běží ve zkušebním režimu. Uvedené informace slouží jen pro demonstraci
+                nastavení a nemusí být platné ani úplné!</small>
+            </li>
+        <#else>
+           <li><small>Údaje v této zprávě jsou pouze informativního charakteru a mohou obsahovat chyby. Směrodatná data
+           poskytuje výhradně <em>Zonky</em> dashboard.</small></li>
+        </#if>
+      </ul>
+      <p>
+        <small>Vygeneroval <em>${data.session.userAgent}</em> dne ${timestamp?date} v ${timestamp?time}. Dotazy
+        pokládejte <a href="https://groups.google.com/forum/#!forum/robozonky-users">v uživatelské skupině</a>.</small>
+      </p>
     </footer>
 
 </body>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/core.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/core.ftl
@@ -1,0 +1,36 @@
+<#setting locale="cs_CZ">
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>${data.subject}</title>
+</head>
+
+<body>
+    <header>
+        <#if data.session.isDryRun>
+           <p>
+                <strong><em>RoboZonky</em> běží ve zkušebním režimu. Následující informace slouží jen pro demonstraci
+                nastavení strategie a nejsou platné!</strong>
+            </p>
+        </#if>
+        <p><em>RoboZonky</em> pro <em>Zonky</em> účet <em>${data.session.userName}</em> Vás tímto informuje o
+            následující operaci:</p>
+    </header>
+
+    <main>
+        <#include embed>
+    </main>
+
+    <footer>
+      <p>Tuto zprávu dostáváte, protože je tak Váš robot nakonfigurován. Neodpovídejte na ni.</p>
+      <p>Všechna data v této zprávě jsou pouze informativního charakteru. Jediné směrodatné údaje poskytuje
+        <em>Zonky</em> dashboard.</p>
+      <p>Dotazy k <em>RoboZonky</em> pokládejte v
+        <a href="https://groups.google.com/forum/#!forum/robozonky-users">uživatelské skupině</a></p>
+      <p>Vygeneroval <em>${data.session.userAgent}</em> dne ${timestamp?date} v ${timestamp?time}.</p>
+    </footer>
+
+</body>
+
+</html>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/crashed.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/crashed.ftl
@@ -1,0 +1,6 @@
+<p>Uvnitř <em>RoboZonky</em> došlo k selhání, robot byl předčasně ukončen. Důvod selhání:</p>
+
+<pre><#if !data.isCauseKnown>neznámý<#else>${data.cause}</#if></pre>
+
+<p>Toto selhání mohlo být způsobeno nedostupností serverů Zonky nebo chybou internetového připojení. I přesto
+doporučujeme překontrolovat nastavení robota.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/daemon-failed.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/daemon-failed.ftl
@@ -1,0 +1,6 @@
+<p>Uvnitř <em>RoboZonky</em> démona došlo k chybě, ten však pokračuje v běhu. Následují detailní informace o chybě:</p>
+
+<pre>${data.cause}</pre>
+
+<p>Toto selhání mohlo být způsobeno chybnou konfigurací nebo chybou uvnitř <em>RoboZonky</em>. Zvažte kontaktovat komunitu
+<em>RoboZonky</em>.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/ending.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/ending.ftl
@@ -1,0 +1,1 @@
+<p><em>RoboZonky</em> byl korektně ukončen a nebude nadále investovat.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/experimental-update-detected.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/experimental-update-detected.ftl
@@ -1,0 +1,7 @@
+<p><em>RoboZonky</em> komunita právě vydala novou experimentální verzi
+<em><a href="http://www.robozonky.cz/">RoboZonky ${data.newVersion}</a></em>!.</p>
+
+<p>Experimentální verze poskytují pohled do kuchyně <em>RoboZonky</em> a jsou určeny pro testování zkušenými uživateli. Přinášejí
+nové funkce, které se v budoucnu mohou a nemusejí dostat do rukou běžným uživatelům.</p>
+
+<p>Experimentální verze mohou obsahovat závažné chyby a neměly by být používány pro skutečné investování!</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/initialized.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/initialized.ftl
@@ -1,0 +1,1 @@
+<p><em>RoboZonky</em> byl právě spuštěn a je připraven provádět investiční operace.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-delegated.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-delegated.ftl
@@ -1,0 +1,28 @@
+<p>Půjčka s následujícími parametry byla předána k investování jiným nástrojem:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Délka splácení:</th>
+    <td>${data.loanTerm?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Požadovaná částka:</th>
+    <td>${data.loanAmount?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Navržená výše investice:</th>
+    <td>${data.loanRecommendation?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Cílový nástroj:</th>
+    <td>${data.confirmationProviderId}</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-made.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-made.ftl
@@ -1,0 +1,29 @@
+<p>Půjčka s následujícími parametry byla úspěšně zainvestována:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Délka splácení:</th>
+    <td>${data.loanTerm?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Investovaná částka:</th>
+    <td>${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Dosažitelný výnos:</th>
+    <td>${data.yield?string.currency} (${data.relativeYield?string.@interest} p. a.)</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+
+<#include "additional-portfolio-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-purchased.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-purchased.ftl
@@ -1,0 +1,29 @@
+<p>Na sekundárním trhu byla právě zakoupena následující participace:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Zbývá splátek:</th>
+    <td>${data.loanTermRemaining?c} z ${data.loanTerm?c}</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Dosažitelný výnos:</th>
+    <td>${data.yield?string.currency} (${data.relativeYield?string.@interest} p. a.)</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+
+<#include "additional-portfolio-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-rejected.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-rejected.ftl
@@ -1,0 +1,27 @@
+<p>Půjčka s následujícími parametry byla zamítnuta:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Délka splácení:</th>
+    <td>${data.loanTerm?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Požadovaná částka:</th>
+    <td>${data.loanAmount?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Navržená výše investice:</th>
+    <td>${data.loanRecommendation?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-skipped.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-skipped.ftl
@@ -1,0 +1,27 @@
+<p>Půjčka s následujícími parametry byla přeskočena:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Délka splácení:</th>
+    <td>${data.loanTerm?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Požadovaná částka:</th>
+    <td>${data.loanAmount?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Navržená výše investice:</th>
+    <td>${data.loanRecommendation?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-sold.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/investment-sold.ftl
@@ -1,0 +1,29 @@
+<p>Participace s následujícími parametry byla úspěšně prodána:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Doba držení:</th>
+    <td>${data.monthsElapsed?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountRemaining?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Dosažený výnos:</th>
+    <td>${data.yield?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+
+<#include "additional-portfolio-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-defaulted.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-defaulted.ftl
@@ -1,0 +1,27 @@
+<p>Půjčka s následujícími parametry byla zesplatněna:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Zbývá splátek:</th>
+    <td>${data.loanTermRemaining?c} z ${data.loanTerm?c}</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountRemaining?string.currency} z ${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+  <tr>
+    <th>Odklad splácení:</th>
+    <td><#if data.postponed>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-delinquent.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-delinquent.ftl
@@ -1,0 +1,33 @@
+<p>Půjčka s následujícími parametry je v prodlení:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Zbývá splátek:</th>
+    <td>${data.loanTermRemaining?c} z ${data.loanTerm?c}</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountRemaining?string.currency} z ${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Po splatnosti od:</th>
+    <td>${data.since?date}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+  <tr>
+    <th>Odklad splácení:</th>
+    <td><#if data.postponed>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-collections-info.ftl">
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-lost.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-lost.ftl
@@ -1,0 +1,15 @@
+<p>Půjčka s následujícími parametry byla odepsána:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Ztraceno:</th>
+    <td>${data.amountRemaining?string.currency} z ${data.amountHeld?string.currency}</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-not-delinquent.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-not-delinquent.ftl
@@ -1,0 +1,28 @@
+<p>Půjčka s následujícími parametry nově není v prodlení:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Zbývá splátek:</th>
+    <td>${data.loanTermRemaining?c} z ${data.loanTerm?c}</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountRemaining?string.currency} z ${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+  <tr>
+    <th>Odklad splácení:</th>
+    <td><#if data.postponed>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-repaid.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/loan-repaid.ftl
@@ -1,0 +1,25 @@
+Půjčka s následujícími parametry byla zcela splacena:
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Doba držení:</th>
+    <td>${data.monthsElapsed?c} měsíců</td>
+  </tr>
+  <tr>
+    <th>Zaplaceno:</th>
+    <td>${data.amountPaid?string.currency} za půjčených ${data.amountHeld?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Dosažený výnos:</th>
+    <td>${data.yield?string.currency}</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">
+
+<#include "additional-portfolio-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/remote-failed.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/remote-failed.ftl
@@ -1,0 +1,12 @@
+<p>Uvnitř <em>RoboZonky</em> démona došlo k chybě v síťové komunikaci. To může mít následující příčiny:</p>
+
+<ul>
+  <li>Výpadek sítového připojení.</li>
+  <li>Výpadek některého ze serverů, se kterými komunikujeme. (<em>Zonky</em>, <em>Zonkoid/Zonkios</em>, ...)</li>
+</ul>
+
+<p>I přesto doporučujeme překontrolovat nastavení robota. Následují detailní informace o chybě:</p>
+
+<pre>${data.cause}</pre>
+
+<p>Robot dále pokračuje v běhu.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/sale-offered.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/sale-offered.ftl
@@ -1,0 +1,23 @@
+<p>Participace s následujícími parametry byla právě vystavena na sekundární trh:</p>
+
+<table>
+  <caption><a href="${data.loanUrl}">#${data.loanId?c} ${data.loanName?cap_first}</a></caption>
+  <tr>
+    <th>Rating:</th>
+    <td>${data.loanRating}</td>
+  </tr>
+  <tr>
+    <th>Zbývá splátek:</th>
+    <td>${data.loanTermRemaining?c}</td>
+  </tr>
+  <tr>
+    <th>Zbývající jistina:</th>
+    <td>${data.amountRemaining?string.currency}</td>
+  </tr>
+  <tr>
+    <th>Záchranná vesta:</th>
+    <td><#if data.insurance>Ano<#else>Ne</#if>.</td>
+  </tr>
+</table>
+
+<#include "additional-loan-info.ftl">

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/target-balance-reached.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/target-balance-reached.ftl
@@ -1,0 +1,4 @@
+<p>Disponibilní zůstatek na <em>Zonky</em> účtu právě dosáhl stanovené hranice ${data.targetBalance?string.currency}.</p>
+
+<#include "additional-portfolio-info.ftl">
+

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/testing.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/testing.ftl
@@ -1,0 +1,2 @@
+<p>Toto je zkušební e-mailová notifikace z <em>RoboZonky</em>. Ukazuje, že je notifikační systém správně nakonfigurován.
+Pokud jste o tuto notifikaci nežádali, ignorujte ji.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/under-minimum-balance.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/under-minimum-balance.ftl
@@ -1,0 +1,4 @@
+<p>Disponibilní zůstatek na Zonky účtu právě klesl pod stanovenou hranici ${data.minimumBalance?string.currency}.</p>
+
+<#include "additional-portfolio-info.ftl">
+

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/update-detected.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/update-detected.ftl
@@ -1,0 +1,6 @@
+<p><em>RoboZonky</em> komunita právě vydala aktualizovanou verzi
+    <em><a href="http://www.robozonky.cz/">RoboZonky ${data.newVersion}</a></em>!</p>
+
+<p>Nové verze obvykle přináší opravy chyb nebo nové funkce - proto doporučujeme aktualizaci nainstalovat hned, jak to
+bude možné. Ve výjimečných případech může být urychlený přechod na novou verzi dokonce nezbytný, neboť mohlo dojít k
+úpravám na serveru <em>Zonky</em>, se kterými si stávající verze <em>RoboZonky</em> neumí poradit.</p>

--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/plaintext/core.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/plaintext/core.ftl
@@ -1,11 +1,11 @@
 <#setting locale="cs_CZ">
 <#if data.session.isDryRun>
 POZOR: RoboZonky běží ve zkušebním režimu. Následující informace slouží jen
-pro demonstraci nastavení strategie a nejsou platné!
+pro demonstraci nastavení a nemusí být platné ani úplné!
 ===============================================================================
 </#if>
 
-RoboZonky pro Zonky účet ${data.session.userName} Vás tímto informuje o následující operaci:
+RoboZonky pro Zonky účet ${data.session.userName} Vás tímto informuje o následující skutečnosti:
 
 <#include embed>
 

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/EmailHandlerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/EmailHandlerTest.java
@@ -19,7 +19,6 @@ package com.github.robozonky.notifications;
 import javax.mail.internet.MimeMessage;
 
 import com.github.robozonky.api.SessionInfo;
-import com.github.robozonky.internal.api.Defaults;
 import com.github.robozonky.notifications.listeners.RoboZonkyTestingEventListener;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -30,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class EmailHandlerTest {
 
@@ -51,10 +50,9 @@ class EmailHandlerTest {
                                                               .getResourceAsStream("notifications-enabled.cfg"));
         final EmailHandler h = new EmailHandler(cs);
         final String subject = "A", body = "B";
-        h.send(SupportedListener.TESTING, new SessionInfo("someone@somewhere.cz"), subject, body);
+        h.send(SupportedListener.TESTING, new SessionInfo("someone@somewhere.cz"), subject, body, body);
         assertThat(EMAIL.getReceivedMessages()).hasSize(originalMessages + 1);
         final MimeMessage m = EMAIL.getReceivedMessages()[originalMessages];
-        assertThat(m.getContentType()).contains(Defaults.CHARSET.displayName());
         assertThat(m.getSubject()).isNotNull().isEqualTo(subject);
         assertThat(m.getFrom()[0].toString()).contains("user@seznam.cz");
     }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/EmailHandlerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/EmailHandlerTest.java
@@ -16,6 +16,8 @@
 
 package com.github.robozonky.notifications;
 
+import java.util.Collections;
+import java.util.Map;
 import javax.mail.internet.MimeMessage;
 
 import com.github.robozonky.api.SessionInfo;
@@ -50,7 +52,37 @@ class EmailHandlerTest {
                                                               .getResourceAsStream("notifications-enabled.cfg"));
         final EmailHandler h = new EmailHandler(cs);
         final String subject = "A", body = "B";
-        h.send(SupportedListener.TESTING, new SessionInfo("someone@somewhere.cz"), subject, body, body);
+        h.offer(new Submission() {
+            @Override
+            public SessionInfo getSessionInfo() {
+                return new SessionInfo("someone@somewhere.cz");
+            }
+
+            @Override
+            public SupportedListener getSupportedListener() {
+                return SupportedListener.TESTING;
+            }
+
+            @Override
+            public Map<String, Object> getData() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public String getSubject() {
+                return subject;
+            }
+
+            @Override
+            public String getMessage(final Map<String, Object> data) {
+                return body;
+            }
+
+            @Override
+            public String getFallbackMessage(final Map<String, Object> data) {
+                return body;
+            }
+        });
         assertThat(EMAIL.getReceivedMessages()).hasSize(originalMessages + 1);
         final MimeMessage m = EMAIL.getReceivedMessages()[originalMessages];
         assertThat(m.getSubject()).isNotNull().isEqualTo(subject);

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
@@ -24,6 +24,9 @@ import java.net.URL;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import com.github.robozonky.api.SessionInfo;
@@ -125,8 +128,10 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
 
     private static <T extends Event> void testHtmlProcessing(final AbstractListener<T> listener,
                                                              final T event) throws IOException, TemplateException {
+        final Map<String, Object> data = new HashMap<>(listener.getData(event, SESSION_INFO));
+        data.put("subject", UUID.randomUUID().toString());
         final String s = TemplateProcessor.INSTANCE.processHtml(listener.getTemplateFileName(),
-                                                                listener.getData(event, SESSION_INFO));
+                                                                Collections.unmodifiableMap(data));
         assertThat(s).contains(Defaults.ROBOZONKY_URL);
     }
 

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
@@ -157,7 +157,7 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
                                                         final T event) throws Exception {
         BalanceTracker.reset(SESSION_INFO);
         listener.handle(event, SESSION_INFO);
-        verify(h, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
+        verify(h, times(1)).send(notNull(), notNull(), notNull(), notNull());
     }
 
     @SuppressWarnings("unchecked")
@@ -188,10 +188,10 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
         final AbstractTargetHandler p = getHandler(cs);
         final TestingEmailingListener l = new TestingEmailingListener(p);
         l.handle(EVENT, SESSION_INFO);
-        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
+        verify(p, times(1)).send(notNull(), notNull(), notNull(), notNull());
         l.handle(EVENT, SESSION_INFO);
         // e-mail not re-sent, finisher not called again
-        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
+        verify(p, times(1)).send(notNull(), notNull(), notNull(), notNull());
     }
 
     @BeforeEach
@@ -277,8 +277,8 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
         }
 
         @Override
-        public void actuallySend(final SessionInfo sessionInfo, final String subject, final String message,
-                                 final String fallbackMessage) {
+        public void send(final SessionInfo sessionInfo, final String subject, final String message,
+                         final String fallbackMessage) {
 
         }
     }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/AbstractListenerTest.java
@@ -116,10 +116,17 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
                 .isNotEmpty();
     }
 
-    private static <T extends Event> void testProcessing(final AbstractListener<T> listener,
-                                                         final T event) throws IOException, TemplateException {
-        final String s = TemplateProcessor.INSTANCE.process(listener.getTemplateFileName(),
-                                                            listener.getData(event, SESSION_INFO));
+    private static <T extends Event> void testPlainTextProcessing(final AbstractListener<T> listener,
+                                                                  final T event) throws IOException, TemplateException {
+        final String s = TemplateProcessor.INSTANCE.processPlainText(listener.getTemplateFileName(),
+                                                                     listener.getData(event, SESSION_INFO));
+        assertThat(s).contains(Defaults.ROBOZONKY_URL);
+    }
+
+    private static <T extends Event> void testHtmlProcessing(final AbstractListener<T> listener,
+                                                             final T event) throws IOException, TemplateException {
+        final String s = TemplateProcessor.INSTANCE.processHtml(listener.getTemplateFileName(),
+                                                                listener.getData(event, SESSION_INFO));
         assertThat(s).contains(Defaults.ROBOZONKY_URL);
     }
 
@@ -145,7 +152,7 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
                                                         final T event) throws Exception {
         BalanceTracker.reset(SESSION_INFO);
         listener.handle(event, SESSION_INFO);
-        verify(h, times(1)).actuallySend(notNull(), notNull(), notNull());
+        verify(h, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
     }
 
     @SuppressWarnings("unchecked")
@@ -155,7 +162,8 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
         final AbstractListener<T> l = (AbstractListener<T>) getListener(listener, p);
         return DynamicContainer.dynamicContainer(listener.toString(), Stream.of(
                 dynamicTest("is formally correct", () -> testFormal(l, e, listener)),
-                dynamicTest("is processed correctly", () -> testProcessing(l, e)),
+                dynamicTest("is processed as plain text", () -> testPlainTextProcessing(l, e)),
+                dynamicTest("is processed as HTML", () -> testHtmlProcessing(l, e)),
                 dynamicTest("triggers the sending code", () -> testTriggered(p, l, e)),
                 dynamicTest("has listener enabled", () -> testListenerEnabled(e))
         ));
@@ -175,10 +183,10 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
         final AbstractTargetHandler p = getHandler(cs);
         final TestingEmailingListener l = new TestingEmailingListener(p);
         l.handle(EVENT, SESSION_INFO);
-        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull());
+        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
         l.handle(EVENT, SESSION_INFO);
         // e-mail not re-sent, finisher not called again
-        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull());
+        verify(p, times(1)).actuallySend(notNull(), notNull(), notNull(), notNull());
     }
 
     @BeforeEach
@@ -264,7 +272,8 @@ public class AbstractListenerTest extends AbstractRoboZonkyTest {
         }
 
         @Override
-        public void actuallySend(final SessionInfo sessionInfo, final String subject, final String message) {
+        public void actuallySend(final SessionInfo sessionInfo, final String subject, final String message,
+                                 final String fallbackMessage) {
 
         }
     }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceOnTargetEventListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceOnTargetEventListenerTest.java
@@ -28,7 +28,14 @@ import com.github.robozonky.notifications.Target;
 import com.github.robozonky.test.AbstractRoboZonkyTest;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class BalanceOnTargetEventListenerTest extends AbstractRoboZonkyTest {
 
@@ -37,7 +44,7 @@ class BalanceOnTargetEventListenerTest extends AbstractRoboZonkyTest {
     @Test
     void check() throws Exception {
         final AbstractTargetHandler h = mock(AbstractTargetHandler.class);
-        doNothing().when(h).send(any(), any(), any(), any());
+        doNothing().when(h).send(any(), any(), any(), any(), any());
         when(h.getTarget()).thenReturn(Target.EMAIL);
         when(h.getListenerSpecificIntProperty(eq(SupportedListener.BALANCE_ON_TARGET), eq("targetBalance"), anyInt()))
                 .thenAnswer(i -> i.getArgument(2));
@@ -46,14 +53,14 @@ class BalanceOnTargetEventListenerTest extends AbstractRoboZonkyTest {
         final AbstractListener<ExecutionStartedEvent> l =
                 new BalanceOnTargetEventListener(SupportedListener.BALANCE_ON_TARGET, h);
         l.handle(evt, SESSION_INFO); // balance change
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         l.handle(evt, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         final PortfolioOverview p2 = PortfolioOverview.calculate(BigDecimal.ZERO, Collections.emptyMap());
         final ExecutionStartedEvent evt2 = new ExecutionStartedEvent(Collections.emptyList(), p2);
         l.handle(evt2, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         l.handle(evt, SESSION_INFO); // back over threshold, send notification
-        verify(h, times(2)).send(any(), any(), any(), any());
+        verify(h, times(2)).send(any(), any(), any(), any(), any());
     }
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceOnTargetEventListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceOnTargetEventListenerTest.java
@@ -44,7 +44,7 @@ class BalanceOnTargetEventListenerTest extends AbstractRoboZonkyTest {
     @Test
     void check() throws Exception {
         final AbstractTargetHandler h = mock(AbstractTargetHandler.class);
-        doNothing().when(h).send(any(), any(), any(), any(), any());
+        doNothing().when(h).offer(any());
         when(h.getTarget()).thenReturn(Target.EMAIL);
         when(h.getListenerSpecificIntProperty(eq(SupportedListener.BALANCE_ON_TARGET), eq("targetBalance"), anyInt()))
                 .thenAnswer(i -> i.getArgument(2));
@@ -53,14 +53,14 @@ class BalanceOnTargetEventListenerTest extends AbstractRoboZonkyTest {
         final AbstractListener<ExecutionStartedEvent> l =
                 new BalanceOnTargetEventListener(SupportedListener.BALANCE_ON_TARGET, h);
         l.handle(evt, SESSION_INFO); // balance change
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         l.handle(evt, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         final PortfolioOverview p2 = PortfolioOverview.calculate(BigDecimal.ZERO, Collections.emptyMap());
         final ExecutionStartedEvent evt2 = new ExecutionStartedEvent(Collections.emptyList(), p2);
         l.handle(evt2, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         l.handle(evt, SESSION_INFO); // back over threshold, send notification
-        verify(h, times(2)).send(any(), any(), any(), any(), any());
+        verify(h, times(2)).offer(any());
     }
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceUnderMinimumEventListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceUnderMinimumEventListenerTest.java
@@ -28,7 +28,14 @@ import com.github.robozonky.notifications.Target;
 import com.github.robozonky.test.AbstractRoboZonkyTest;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class BalanceUnderMinimumEventListenerTest extends AbstractRoboZonkyTest {
 
@@ -37,7 +44,7 @@ class BalanceUnderMinimumEventListenerTest extends AbstractRoboZonkyTest {
     @Test
     void check() throws Exception {
         final AbstractTargetHandler h = mock(AbstractTargetHandler.class);
-        doNothing().when(h).send(any(), any(), any(), any());
+        doNothing().when(h).send(any(), any(), any(), any(), any());
         when(h.getTarget()).thenReturn(Target.EMAIL);
         when(h.getListenerSpecificIntProperty(eq(SupportedListener.BALANCE_UNDER_MINIMUM), eq("minimumBalance"),
                                               anyInt()))
@@ -47,14 +54,14 @@ class BalanceUnderMinimumEventListenerTest extends AbstractRoboZonkyTest {
         final AbstractListener<ExecutionStartedEvent> l =
                 new BalanceUnderMinimumEventListener(SupportedListener.BALANCE_UNDER_MINIMUM, h);
         l.handle(evt, SESSION_INFO); // balance change
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         l.handle(evt, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         final PortfolioOverview p2 = PortfolioOverview.calculate(BigDecimal.valueOf(1000), Collections.emptyMap());
         final ExecutionStartedEvent evt2 = new ExecutionStartedEvent(Collections.emptyList(), p2);
         l.handle(evt2, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any());
+        verify(h, times(1)).send(any(), any(), any(), any(), any());
         l.handle(evt, SESSION_INFO); // back over threshold, send notification
-        verify(h, times(2)).send(any(), any(), any(), any());
+        verify(h, times(2)).send(any(), any(), any(), any(), any());
     }
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceUnderMinimumEventListenerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/BalanceUnderMinimumEventListenerTest.java
@@ -44,7 +44,7 @@ class BalanceUnderMinimumEventListenerTest extends AbstractRoboZonkyTest {
     @Test
     void check() throws Exception {
         final AbstractTargetHandler h = mock(AbstractTargetHandler.class);
-        doNothing().when(h).send(any(), any(), any(), any(), any());
+        doNothing().when(h).offer(any());
         when(h.getTarget()).thenReturn(Target.EMAIL);
         when(h.getListenerSpecificIntProperty(eq(SupportedListener.BALANCE_UNDER_MINIMUM), eq("minimumBalance"),
                                               anyInt()))
@@ -54,14 +54,14 @@ class BalanceUnderMinimumEventListenerTest extends AbstractRoboZonkyTest {
         final AbstractListener<ExecutionStartedEvent> l =
                 new BalanceUnderMinimumEventListener(SupportedListener.BALANCE_UNDER_MINIMUM, h);
         l.handle(evt, SESSION_INFO); // balance change
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         l.handle(evt, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         final PortfolioOverview p2 = PortfolioOverview.calculate(BigDecimal.valueOf(1000), Collections.emptyMap());
         final ExecutionStartedEvent evt2 = new ExecutionStartedEvent(Collections.emptyList(), p2);
         l.handle(evt2, SESSION_INFO); // no change, no notification
-        verify(h, times(1)).send(any(), any(), any(), any(), any());
+        verify(h, times(1)).offer(any());
         l.handle(evt, SESSION_INFO); // back over threshold, send notification
-        verify(h, times(2)).send(any(), any(), any(), any(), any());
+        verify(h, times(2)).offer(any());
     }
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/DelinquencyTrackerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/DelinquencyTrackerTest.java
@@ -49,15 +49,6 @@ import static org.mockito.Mockito.verify;
 
 class DelinquencyTrackerTest extends AbstractRoboZonkyTest {
 
-    public static URL getSomeUrl() {
-        try {
-            return new URL("http://localhost");
-        } catch (final MalformedURLException ex) {
-            Assertions.fail("Shouldn't have happened.", ex);
-            return null;
-        }
-    }
-
     private static final Loan LOAN = Loan.custom()
             .setId(1)
             .setAmount(200)
@@ -72,6 +63,15 @@ class DelinquencyTrackerTest extends AbstractRoboZonkyTest {
             .setInvestmentDate(OffsetDateTime.now())
             .build();
     private static SessionInfo SESSION = new SessionInfo("someone@robozonky.cz");
+
+    public static URL getSomeUrl() {
+        try {
+            return new URL("http://localhost");
+        } catch (final MalformedURLException ex) {
+            Assertions.fail("Shouldn't have happened.", ex);
+            return null;
+        }
+    }
 
     @Test
     void standard() {
@@ -92,14 +92,13 @@ class DelinquencyTrackerTest extends AbstractRoboZonkyTest {
                 new LoanNoLongerDelinquentEventListener(SupportedListener.LOAN_NO_LONGER_DELINQUENT, h);
         final LoanNoLongerDelinquentEvent evt = new LoanNoLongerDelinquentEvent(INVESTMENT, LOAN);
         l2.handle(evt, SESSION);
-        verify(h, never()).actuallySend(any(), any(), any()); // not delinquent before, not sending
+        verify(h, never()).actuallySend(any(), any(), any(), any()); // not delinquent before, not sending
         l.handle(new LoanDelinquent10DaysOrMoreEvent(INVESTMENT, LOAN, LocalDate.now(), Collections.emptyList()),
                  SESSION);
-        verify(h).actuallySend(eq(SESSION), any(), any());
+        verify(h).actuallySend(eq(SESSION), any(), any(), any());
         l2.handle(evt, SESSION);
-        verify(h, times(2)).actuallySend(eq(SESSION), any(), any()); // delinquency now registered, send
+        verify(h, times(2)).actuallySend(eq(SESSION), any(), any(), any()); // delinquency now registered, send
         l2.handle(evt, SESSION);
-        verify(h, times(2)).actuallySend(eq(SESSION), any(), any()); // already unregistered, no send
+        verify(h, times(2)).actuallySend(eq(SESSION), any(), any(), any()); // already unregistered, no send
     }
-
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/DelinquencyTrackerTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/listeners/DelinquencyTrackerTest.java
@@ -92,13 +92,13 @@ class DelinquencyTrackerTest extends AbstractRoboZonkyTest {
                 new LoanNoLongerDelinquentEventListener(SupportedListener.LOAN_NO_LONGER_DELINQUENT, h);
         final LoanNoLongerDelinquentEvent evt = new LoanNoLongerDelinquentEvent(INVESTMENT, LOAN);
         l2.handle(evt, SESSION);
-        verify(h, never()).actuallySend(any(), any(), any(), any()); // not delinquent before, not sending
+        verify(h, never()).send(any(), any(), any(), any()); // not delinquent before, not sending
         l.handle(new LoanDelinquent10DaysOrMoreEvent(INVESTMENT, LOAN, LocalDate.now(), Collections.emptyList()),
                  SESSION);
-        verify(h).actuallySend(eq(SESSION), any(), any(), any());
+        verify(h).send(eq(SESSION), any(), any(), any());
         l2.handle(evt, SESSION);
-        verify(h, times(2)).actuallySend(eq(SESSION), any(), any(), any()); // delinquency now registered, send
+        verify(h, times(2)).send(eq(SESSION), any(), any(), any()); // delinquency now registered, send
         l2.handle(evt, SESSION);
-        verify(h, times(2)).actuallySend(eq(SESSION), any(), any(), any()); // already unregistered, no send
+        verify(h, times(2)).send(eq(SESSION), any(), any(), any()); // already unregistered, no send
     }
 }

--- a/robozonky-notifications/src/test/java/com/github/robozonky/notifications/templates/TemplateProcessorTest.java
+++ b/robozonky-notifications/src/test/java/com/github/robozonky/notifications/templates/TemplateProcessorTest.java
@@ -19,16 +19,33 @@ package com.github.robozonky.notifications.templates;
 import java.util.Locale;
 
 import com.github.robozonky.internal.api.Defaults;
+import com.github.robozonky.notifications.templates.html.HtmlTemplate;
+import com.github.robozonky.notifications.templates.plaintext.PlainTextTemplate;
 import freemarker.template.Configuration;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.SoftAssertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class TemplateProcessorTest {
 
     @Test
-    void properConfiguration() {
-        final Configuration configuration = TemplateProcessor.getFreemarkerConfiguration();
+    void properPlainTextConfiguration() {
+        final Configuration configuration = TemplateProcessor.getFreemarkerConfiguration(PlainTextTemplate.class);
+        final String targetEncoding = Defaults.CHARSET.toString();
+        assertSoftly(softly -> {
+            softly.assertThat(configuration.getCustomNumberFormat("interest"))
+                    .isInstanceOf(InterestNumberFormatFactory.class);
+            softly.assertThat(configuration.getLogTemplateExceptions()).isFalse();
+            softly.assertThat(configuration.getDefaultEncoding()).isEqualTo(targetEncoding);
+            softly.assertThat(configuration.getEncoding(Locale.getDefault())).isEqualTo(targetEncoding);
+            softly.assertThat(configuration.getEncoding(Locale.ENGLISH)).isEqualTo(targetEncoding);
+            softly.assertThat(configuration.getEncoding(Defaults.LOCALE)).isEqualTo(targetEncoding);
+        });
+    }
+
+    @Test
+    void properHtmlConfiguration() {
+        final Configuration configuration = TemplateProcessor.getFreemarkerConfiguration(HtmlTemplate.class);
         final String targetEncoding = Defaults.CHARSET.toString();
         assertSoftly(softly -> {
             softly.assertThat(configuration.getCustomNumberFormat("interest"))


### PR DESCRIPTION
- The notifications are very plain, having no CSS.
- The e-mails still carry the plain-text information as a fallback for dumb e-mail clients.
- The e-mailing code is now much faster, as the e-mails are only being created after we're 100 % sure we'll be sending them.