### PR TITLE
Speed up testing by reusing JVM forks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,30 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
+        <version>1.4.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>0.7</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <skip>${skipTests}</skip>
+          <timestampedReports>false</timestampedReports>
+          <coverageThreshold>85</coverageThreshold>
+          <mutationThreshold>85</mutationThreshold>
+          <targetClasses>
+            <param>com.github.robozonky.*</param>
+          </targetClasses>
+          <excludedMethods>
+            <param>hashCode</param>
+            <param>toString</param>
+          </excludedMethods>
+          <jvmArgs> <!-- some tests may fail on non-UTF-8 machines -->
+            <value>-Dfile.encoding=${project.build.sourceEncoding}</value>
+          </jvmArgs>
+        </configuration>
         <executions>
           <execution>
             <id>fail-on-coverage</id>
@@ -429,34 +453,6 @@
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.pitest</groupId>
-          <artifactId>pitest-maven</artifactId>
-          <version>1.4.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.pitest</groupId>
-              <artifactId>pitest-junit5-plugin</artifactId>
-              <version>0.5</version>
-            </dependency>
-          </dependencies>
-          <configuration>
-            <skip>${skipTests}</skip>
-            <timestampedReports>false</timestampedReports>
-            <coverageThreshold>85</coverageThreshold>
-            <mutationThreshold>85</mutationThreshold>
-            <targetClasses>
-              <param>com.github.robozonky.*</param>
-            </targetClasses>
-            <excludedMethods>
-              <param>hashCode</param>
-              <param>toString</param>
-            </excludedMethods>
-            <jvmArgs> <!-- some tests may fail on non-UTF-8 machines -->
-              <value>-Dfile.encoding=${project.build.sourceEncoding}</value>
-            </jvmArgs>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <version.org.jboss.resteasy>3.6.1.Final</version.org.jboss.resteasy>
     <version.org.junit5>3.1</version.org.junit5>
     <version.org.junit>5.${version.org.junit5}</version.org.junit>
+    <version.org.junit.platform>1.${version.org.junit5}</version.org.junit.platform>
     <version.org.slf4j>1.7.25</version.org.slf4j>
     <!-- For whatever reason, SMTP auth fails in Windows with the default version. -->
     <version.com.sun.mail>1.6.2</version.com.sun.mail>
@@ -266,7 +267,7 @@
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
-        <version>1.${version.org.junit5}</version>
+        <version>${version.org.junit.platform}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -462,6 +463,18 @@
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <workingDirectory>${basedir}/target</workingDirectory>
           </configuration>
+          <dependencies> <!-- possibly remove this after https://github.com/apache/maven-surefire/pull/193 is fixed -->
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-launcher</artifactId>
+              <version>${version.org.junit.platform}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-engine</artifactId>
+              <version>${version.org.junit.platform}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
     <version.org.antlr>4.7.1</version.org.antlr>
     <version.org.codehaus.izpack>5.1.3</version.org.codehaus.izpack>
     <version.org.jboss.resteasy>3.6.1.Final</version.org.jboss.resteasy>
-    <version.org.junit>5.2.0</version.org.junit>
+    <version.org.junit5>3.1</version.org.junit5>
+    <version.org.junit>5.${version.org.junit5}</version.org.junit>
     <version.org.slf4j>1.7.25</version.org.slf4j>
     <!-- For whatever reason, SMTP auth fails in Windows with the default version. -->
     <version.com.sun.mail>1.6.2</version.com.sun.mail>
@@ -265,7 +266,7 @@
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
-        <version>1.2.0</version>
+        <version>1.${version.org.junit5}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.version}</version>
           <configuration>
-            <reuseForks>false</reuseForks>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <workingDirectory>${basedir}/target</workingDirectory>
           </configuration>

--- a/robozonky-api/src/test/java/com/github/robozonky/internal/api/SettingsTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/internal/api/SettingsTest.java
@@ -37,6 +37,7 @@ class SettingsTest {
     @AfterEach
     void reinit() {
         Settings.INSTANCE.reinit();
+        System.clearProperty(Settings.FILE_LOCATION_PROPERTY);
     }
 
     @Test

--- a/robozonky-common/src/main/java/com/github/robozonky/util/IoUtil.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/util/IoUtil.java
@@ -32,6 +32,7 @@ public final class IoUtil {
      * conditions.
      * @param in
      * @param f
+     * @param <S>
      * @param <T>
      * @return
      * @throws IOException
@@ -43,6 +44,16 @@ public final class IoUtil {
         }
     }
 
+    /**
+     * The whole point of this method existing is that PITest will generate several entirely untestable mutations in the
+     * try-with-resources blocks, complaining of untested calls to close() etc. Instead of crippling the code by no
+     * longer using try-with-resources, we centralize all those calls to this method, where we can test all the
+     * conditions.
+     * @param in
+     * @param f
+     * @param <S>
+     * @throws IOException
+     */
     public static <S extends Closeable> void acceptCloseable(final ThrowingSupplier<S> in,
                                                              final ThrowingConsumer<S> f) throws IOException {
         try (final S s = in.get()) {


### PR DESCRIPTION
This is also likely to help later when we're converting the codebase to JPMS and the only way to do that with Surefire currently is to disable forking altogether.