### PR TITLE
Work around Zonky's cache problems

### DIFF
--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/BlockedAmountProcessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/BlockedAmountProcessor.java
@@ -43,7 +43,7 @@ public class BlockedAmountProcessor implements PortfolioDependant {
 
     private final Map<Integer, Blocked> syntheticByLoanId = new ConcurrentHashMap<>(0);
     private final AtomicReference<Map<Rating, BigDecimal>> adjustments = new AtomicReference<>(Collections.emptyMap());
-    private final AtomicReference<Map<Long, Blocked>> realById = new AtomicReference<>(Collections.emptyMap());
+    private final AtomicReference<Map<Integer, Blocked>> realById = new AtomicReference<>(Collections.emptyMap());
 
     public static BlockedAmountProcessor create(final Tenant tenant) {
         final BlockedAmountProcessor result = new BlockedAmountProcessor();
@@ -56,7 +56,7 @@ public class BlockedAmountProcessor implements PortfolioDependant {
         return LazyInitialized.create(() -> BlockedAmountProcessor.create(tenant));
     }
 
-    private Map<Long, Blocked> readBlockedAmounts(final Tenant tenant) {
+    private Map<Integer, Blocked> readBlockedAmounts(final Tenant tenant) {
         final long portfolioSize = tenant.call(Zonky::getStatistics).getCurrentOverview().getPrincipalLeft();
         final LongAdder adder = new LongAdder();
         return tenant.call(Zonky::getBlockedAmounts)
@@ -137,7 +137,7 @@ public class BlockedAmountProcessor implements PortfolioDependant {
 
     private static final class Blocked {
 
-        private final long id;
+        private final int id;
         private final BigDecimal amount;
         private final Rating rating;
 
@@ -153,7 +153,7 @@ public class BlockedAmountProcessor implements PortfolioDependant {
             this.rating = rating;
         }
 
-        public long getId() {
+        public int getId() {
             return id;
         }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/BlockedAmountProcessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/BlockedAmountProcessor.java
@@ -74,16 +74,18 @@ public class BlockedAmountProcessor implements PortfolioDependant {
                          * ever finishing the portfolio update. As a result, the robot would not be able to do
                          * anything. Comparatively, being wrong by 0,5 % is not so bad.
                          */
+                        LOGGER.warn("Zonky API mistakenly reports loan #{} as non-existent. " +
+                                            "Consider reporting this to Zonky so that they can fix it.",
+                                    loanId, ex);
+                        if (syntheticByLoanId.containsKey(loanId)) { // we have the loan as synthetic, no need to worry
+                            return Stream.empty();
+                        }
                         final BigDecimal amount = ba.getAmount();
                         divisor.add(amount.longValue());
                         final long shareThatIsWrongPerMille = divisor.getSharePerMille();
-                        LOGGER.warn("Zonky API mistakenly reports loan #{} as non-existent. " +
-                                            "Consider reporting this to Zonky so that they can fix it. " +
-                                            "In the meantime, RoboZonky portfolio structure will be off by {} ‰.",
-                                    loanId, shareThatIsWrongPerMille, ex);
                         if (shareThatIsWrongPerMille >= 5) {
                             throw new IllegalStateException("RoboZonky portfolio structure is too far off.", ex);
-                        } else {
+                        } else { // let this slide as the portfolio is only a little bit off
                             return Stream.empty();
                         }
                     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Divisor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Divisor.java
@@ -32,6 +32,9 @@ final class Divisor {
     }
 
     public long getSharePerMille() {
+        if (max < 1) {
+            return Long.MAX_VALUE;
+        }
         return (adder.sum() * 1000) / max;
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Divisor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Divisor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import java.util.concurrent.atomic.LongAdder;
+
+final class Divisor {
+
+    private final long max;
+    private final LongAdder adder = new LongAdder();
+
+    public Divisor(final long max) {
+        this.max = max;
+    }
+
+    public void add(final long number) {
+        adder.add(number);
+    }
+
+    public long getSharePerMille() {
+        return (adder.sum() * 1000) / max;
+    }
+
+}

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DivisorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DivisorTest.java
@@ -32,4 +32,12 @@ class DivisorTest {
         assertThat(d.getSharePerMille()).isEqualTo(11);
     }
 
+    @Test
+    void calculateWithZeroBase() {
+        final Divisor d = new Divisor(0);
+        assertThat(d.getSharePerMille()).isEqualTo(Long.MAX_VALUE);
+        d.add(1);
+        assertThat(d.getSharePerMille()).isEqualTo(Long.MAX_VALUE);
+    }
+
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DivisorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DivisorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DivisorTest {
+
+    @Test
+    void calculate() {
+        final Divisor d = new Divisor(1000);
+        assertThat(d.getSharePerMille()).isEqualTo(0);
+        d.add(1);
+        assertThat(d.getSharePerMille()).isEqualTo(1);
+        d.add(10);
+        assertThat(d.getSharePerMille()).isEqualTo(11);
+    }
+
+}


### PR DESCRIPTION
Zonky occasionally suffers cache inconsistencies. When they happen, they usually show up during processing of blocked amounts, and therefore bring down the entire robot. This code change attempts to fix that by ignoring such rare occasions, until the situation reaches a certain threshold.