### PR TITLE
Only check live marketplace when Zonky reports new loans (closes #387)

### DIFF
--- a/robozonky-api/revapi.json
+++ b/robozonky-api/revapi.json
@@ -245,7 +245,8 @@
         "code": "java.class.externalClassExposedInAPI",
         "new": "enum org.apache.logging.log4j.spi.StandardLevel",
         "justification": "Logging goes through Log4J instead of SLF4J."
-      },{
+      },
+      {
         "code": "java.method.addedToInterface",
         "new": "method java.math.BigDecimal com.github.robozonky.api.remote.entities.sanitized.MarketplaceLoan::getAnnuity()",
         "justification": "Zonky API brings new fields."
@@ -264,7 +265,8 @@
         "code": "java.method.addedToInterface",
         "new": "method T com.github.robozonky.api.remote.entities.sanitized.MutableMarketplaceLoan<T extends com.github.robozonky.api.remote.entities.sanitized.MutableMarketplaceLoan<T extends com.github.robozonky.api.remote.entities.sanitized.MutableMarketplaceLoan<T>>>::setRevenueRate(java.math.BigDecimal)",
         "justification": "Zonky API brings new fields."
-      },{
+      },
+      {
         "code": "java.method.addedToInterface",
         "new": "method java.math.BigDecimal com.github.robozonky.api.remote.entities.sanitized.Investment::getRevenueRate()",
         "justification": "Zonky API brings new fields."
@@ -273,6 +275,11 @@
         "code": "java.method.addedToInterface",
         "new": "method T com.github.robozonky.api.remote.entities.sanitized.MutableInvestment<T extends com.github.robozonky.api.remote.entities.sanitized.MutableInvestment<T extends com.github.robozonky.api.remote.entities.sanitized.MutableInvestment<T>>>::setRevenueRate(java.math.BigDecimal)",
         "justification": "Zonky API brings new fields."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method com.github.robozonky.api.remote.entities.LastPublishedLoan com.github.robozonky.api.remote.LoanApi::lastPublished()",
+        "justification": "We're using a new Zonky API."
       }
     ]
   }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/LoanApi.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/LoanApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.remote.entities.RawLoan;
 import com.github.robozonky.internal.api.Defaults;
 
@@ -39,6 +40,11 @@ public interface LoanApi extends EntityCollectionApi<RawLoan> {
     @Path("marketplace")
     @Override
     List<RawLoan> items();
+
+    @GET
+    @Path("last-published")
+    LastPublishedLoan lastPublished();
+
 
     @GET
     @Path("{loanId}")

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/LastPublishedLoan.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/LastPublishedLoan.java
@@ -20,12 +20,23 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.github.robozonky.internal.util.DateUtil;
+
 public class LastPublishedLoan extends BaseEntity {
 
     @XmlElement
     private int id;
     @XmlElement
     private OffsetDateTime datePublished;
+
+    public LastPublishedLoan(final int loanId) {
+        this(loanId, DateUtil.offsetNow());
+    }
+
+    public LastPublishedLoan(final int loanId, final OffsetDateTime datePublished) {
+        this.id = loanId;
+        this.datePublished = datePublished;
+    }
 
     public int getId() {
         return id;

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/LastPublishedLoan.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/LastPublishedLoan.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.api.remote.entities;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import javax.xml.bind.annotation.XmlElement;
+
+public class LastPublishedLoan extends BaseEntity {
+
+    @XmlElement
+    private int id;
+    @XmlElement
+    private OffsetDateTime datePublished;
+
+    public int getId() {
+        return id;
+    }
+
+    public OffsetDateTime getDatePublished() {
+        return datePublished;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !Objects.equals(getClass(), o.getClass())) {
+            return false;
+        }
+        final LastPublishedLoan that = (LastPublishedLoan) o;
+        return id == that.id &&
+                Objects.equals(datePublished, that.datePublished);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, datePublished);
+    }
+}

--- a/robozonky-api/src/test/java/com/github/robozonky/api/remote/entities/LastPublishedLoanTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/api/remote/entities/LastPublishedLoanTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.api.remote.entities;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static com.github.robozonky.internal.util.DateUtil.offsetNow;
+import static org.assertj.core.api.Assertions.*;
+
+class LastPublishedLoanTest {
+
+    @Test
+    void equality() {
+        final LastPublishedLoan l = new LastPublishedLoan(1);
+        assertThat(l).isEqualTo(l);
+        assertThat(l).isNotEqualTo(null);
+        assertThat(l).isNotEqualTo("");
+        final LastPublishedLoan equal = new LastPublishedLoan(l.getId(), l.getDatePublished());
+        assertThat(l).isEqualTo(equal);
+        assertThat(equal).isEqualTo(l);
+        final LastPublishedLoan diff = new LastPublishedLoan(l.getId(), offsetNow().plus(Duration.ofSeconds(1)));
+        assertThat(diff).isNotEqualTo(l);
+        assertThat(l).isNotEqualTo(diff);
+    }
+}

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
@@ -19,7 +19,6 @@ package com.github.robozonky.app.configuration;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -60,12 +59,6 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
     @picocli.CommandLine.Option(names = {"-g", "--guarded"},
             description = "Path to secure file that contains username, password etc.", required = true)
     private File keystore = null;
-    @picocli.CommandLine.Option(names = {"-w", "--wait-primary", "--wait"},
-            description = "Number of seconds between consecutive checks of primary marketplace.")
-    private int primaryMarketplaceCheckDelay = 1;
-    @picocli.CommandLine.Option(names = {"-ws", "--wait-secondary"},
-            description = "Number of seconds between consecutive checks of secondary marketplace.")
-    private int secondaryMarketplaceCheckDelay = primaryMarketplaceCheckDelay;
 
     public CommandLine(final Supplier<Lifecycle> lifecycle) {
         this.lifecycle = lifecycle;
@@ -85,14 +78,6 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
         final CommandLine cli = new CommandLine(main::getLifecycle);
         final Optional<InvestmentMode> result = picocli.CommandLine.call(cli, main.getArgs());
         return Objects.isNull(result) ? Optional.empty() : result;
-    }
-
-    Duration getPrimaryMarketplaceCheckDelay() {
-        return Duration.ofSeconds(primaryMarketplaceCheckDelay);
-    }
-
-    Duration getSecondaryMarketplaceCheckDelay() {
-        return Duration.ofSeconds(secondaryMarketplaceCheckDelay);
     }
 
     Optional<String> getConfirmationCredentials() {

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
@@ -19,6 +19,7 @@ package com.github.robozonky.app.configuration;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -59,6 +60,12 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
     @picocli.CommandLine.Option(names = {"-g", "--guarded"},
             description = "Path to secure file that contains username, password etc.", required = true)
     private File keystore = null;
+    @picocli.CommandLine.Option(names = {"-w", "--wait-primary", "--wait"},
+            description = "Number of seconds between consecutive checks of primary marketplace.")
+    private int primaryMarketplaceCheckDelay = 1;
+    @picocli.CommandLine.Option(names = {"-ws", "--wait-secondary"},
+            description = "Number of seconds between consecutive checks of secondary marketplace.")
+    private int secondaryMarketplaceCheckDelay = primaryMarketplaceCheckDelay;
 
     public CommandLine(final Supplier<Lifecycle> lifecycle) {
         this.lifecycle = lifecycle;
@@ -78,6 +85,14 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
         final CommandLine cli = new CommandLine(main::getLifecycle);
         final Optional<InvestmentMode> result = picocli.CommandLine.call(cli, main.getArgs());
         return Objects.isNull(result) ? Optional.empty() : result;
+    }
+
+    Duration getPrimaryMarketplaceCheckDelay() {
+        return Duration.ofSeconds(primaryMarketplaceCheckDelay);
+    }
+
+    Duration getSecondaryMarketplaceCheckDelay() {
+        return Duration.ofSeconds(secondaryMarketplaceCheckDelay);
     }
 
     Optional<String> getConfirmationCredentials() {

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/CommandLine.java
@@ -60,12 +60,9 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
     @picocli.CommandLine.Option(names = {"-g", "--guarded"},
             description = "Path to secure file that contains username, password etc.", required = true)
     private File keystore = null;
-    @picocli.CommandLine.Option(names = {"-w", "--wait-primary", "--wait"},
-            description = "Number of seconds between consecutive checks of primary marketplace.")
-    private int primaryMarketplaceCheckDelay = 1;
     @picocli.CommandLine.Option(names = {"-ws", "--wait-secondary"},
             description = "Number of seconds between consecutive checks of secondary marketplace.")
-    private int secondaryMarketplaceCheckDelay = primaryMarketplaceCheckDelay;
+    private int secondaryMarketplaceCheckDelay = 1;
 
     public CommandLine(final Supplier<Lifecycle> lifecycle) {
         this.lifecycle = lifecycle;
@@ -85,10 +82,6 @@ public class CommandLine implements Callable<Optional<InvestmentMode>> {
         final CommandLine cli = new CommandLine(main::getLifecycle);
         final Optional<InvestmentMode> result = picocli.CommandLine.call(cli, main.getArgs());
         return Objects.isNull(result) ? Optional.empty() : result;
-    }
-
-    Duration getPrimaryMarketplaceCheckDelay() {
-        return Duration.ofSeconds(primaryMarketplaceCheckDelay);
     }
 
     Duration getSecondaryMarketplaceCheckDelay() {

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
@@ -95,8 +95,9 @@ final class OperatingMode {
 
     private Optional<InvestmentMode> getInvestmentMode(final CommandLine cli, final PowerTenant auth,
                                                        final Investor investor) {
-        final InvestmentMode m = new DaemonInvestmentMode(t -> lifecycle.get().resumeToFail(t), auth, investor
-        );
+        final InvestmentMode m = new DaemonInvestmentMode(t -> lifecycle.get().resumeToFail(t), auth, investor,
+                                                          cli.getPrimaryMarketplaceCheckDelay(),
+                                                          cli.getSecondaryMarketplaceCheckDelay());
         return Optional.of(m);
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
@@ -95,9 +95,8 @@ final class OperatingMode {
 
     private Optional<InvestmentMode> getInvestmentMode(final CommandLine cli, final PowerTenant auth,
                                                        final Investor investor) {
-        final InvestmentMode m = new DaemonInvestmentMode(t -> lifecycle.get().resumeToFail(t), auth, investor,
-                                                          cli.getPrimaryMarketplaceCheckDelay(),
-                                                          cli.getSecondaryMarketplaceCheckDelay());
+        final InvestmentMode m = new DaemonInvestmentMode(t -> lifecycle.get().resumeToFail(t), auth, investor
+        );
         return Optional.of(m);
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/configuration/OperatingMode.java
@@ -96,7 +96,6 @@ final class OperatingMode {
     private Optional<InvestmentMode> getInvestmentMode(final CommandLine cli, final PowerTenant auth,
                                                        final Investor investor) {
         final InvestmentMode m = new DaemonInvestmentMode(t -> lifecycle.get().resumeToFail(t), auth, investor,
-                                                          cli.getPrimaryMarketplaceCheckDelay(),
                                                           cli.getSecondaryMarketplaceCheckDelay());
         return Optional.of(m);
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/DaemonInvestmentMode.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/DaemonInvestmentMode.java
@@ -36,25 +36,22 @@ public class DaemonInvestmentMode implements InvestmentMode {
     private static final Logger LOGGER = LogManager.getLogger(DaemonInvestmentMode.class);
     private final PowerTenant tenant;
     private final Investor investor;
-    private final Duration primaryMarketplaceCheckPeriod;
     private final Duration secondaryMarketplaceCheckPeriod;
     private final Consumer<Throwable> shutdownCall;
 
     public DaemonInvestmentMode(final Consumer<Throwable> shutdownCall, final PowerTenant tenant,
-                                final Investor investor, final Duration primaryMarketplaceCheckPeriod,
+                                final Investor investor,
                                 final Duration secondaryMarketplaceCheckPeriod) {
         this.tenant = tenant;
         this.investor = investor;
-        this.primaryMarketplaceCheckPeriod = primaryMarketplaceCheckPeriod;
         this.secondaryMarketplaceCheckPeriod = secondaryMarketplaceCheckPeriod;
         this.shutdownCall = shutdownCall;
     }
 
     DaemonInvestmentMode(final PowerTenant tenant, final Investor investor,
-                         final Duration primaryMarketplaceCheckPeriod,
                          final Duration secondaryMarketplaceCheckPeriod) {
         this(t -> {
-        }, tenant, investor, primaryMarketplaceCheckPeriod, secondaryMarketplaceCheckPeriod);
+        }, tenant, investor, secondaryMarketplaceCheckPeriod);
     }
 
     /**
@@ -70,7 +67,7 @@ public class DaemonInvestmentMode implements InvestmentMode {
 
     private void scheduleDaemons(final Scheduler executor) { // run investing and purchasing daemons
         LOGGER.debug("Scheduling daemon threads.");
-        submit(executor, StrategyExecutor.forInvesting(tenant, investor)::get, primaryMarketplaceCheckPeriod);
+        submit(executor, StrategyExecutor.forInvesting(tenant, investor)::get, Duration.ofSeconds(1));
         submit(executor, StrategyExecutor.forPurchasing(tenant)::get, secondaryMarketplaceCheckPeriod,
                Duration.ofMillis(250));
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/DaemonInvestmentMode.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/DaemonInvestmentMode.java
@@ -34,27 +34,21 @@ import org.apache.logging.log4j.Logger;
 public class DaemonInvestmentMode implements InvestmentMode {
 
     private static final Logger LOGGER = LogManager.getLogger(DaemonInvestmentMode.class);
+    private static final Duration MARKETPLACE_CHECK_PERIOD = Duration.ofSeconds(1);
     private final PowerTenant tenant;
     private final Investor investor;
-    private final Duration primaryMarketplaceCheckPeriod;
-    private final Duration secondaryMarketplaceCheckPeriod;
     private final Consumer<Throwable> shutdownCall;
 
     public DaemonInvestmentMode(final Consumer<Throwable> shutdownCall, final PowerTenant tenant,
-                                final Investor investor, final Duration primaryMarketplaceCheckPeriod,
-                                final Duration secondaryMarketplaceCheckPeriod) {
+                                final Investor investor) {
         this.tenant = tenant;
         this.investor = investor;
-        this.primaryMarketplaceCheckPeriod = primaryMarketplaceCheckPeriod;
-        this.secondaryMarketplaceCheckPeriod = secondaryMarketplaceCheckPeriod;
         this.shutdownCall = shutdownCall;
     }
 
-    DaemonInvestmentMode(final PowerTenant tenant, final Investor investor,
-                         final Duration primaryMarketplaceCheckPeriod,
-                         final Duration secondaryMarketplaceCheckPeriod) {
+    DaemonInvestmentMode(final PowerTenant tenant, final Investor investor) {
         this(t -> {
-        }, tenant, investor, primaryMarketplaceCheckPeriod, secondaryMarketplaceCheckPeriod);
+        }, tenant, investor);
     }
 
     /**
@@ -70,9 +64,8 @@ public class DaemonInvestmentMode implements InvestmentMode {
 
     private void scheduleDaemons(final Scheduler executor) { // run investing and purchasing daemons
         LOGGER.debug("Scheduling daemon threads.");
-        submit(executor, StrategyExecutor.forInvesting(tenant, investor)::get, primaryMarketplaceCheckPeriod);
-        submit(executor, StrategyExecutor.forPurchasing(tenant)::get, secondaryMarketplaceCheckPeriod,
-               Duration.ofMillis(250));
+        submit(executor, StrategyExecutor.forInvesting(tenant, investor)::get, MARKETPLACE_CHECK_PERIOD);
+        submit(executor, StrategyExecutor.forPurchasing(tenant)::get, MARKETPLACE_CHECK_PERIOD, Duration.ofMillis(250));
     }
 
     private void submit(final Scheduler executor, final Runnable r, final Duration repeatAfter) {

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,23 +17,18 @@
 package com.github.robozonky.app.daemon;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.github.robozonky.api.strategies.InvestmentStrategy;
 import com.github.robozonky.api.strategies.LoanDescriptor;
-import com.github.robozonky.common.remote.Select;
 import com.github.robozonky.common.tenant.Tenant;
-import com.github.robozonky.internal.util.DateUtil;
 
 class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor, InvestmentStrategy> {
 
-    /**
-     * Will make sure that the endpoint only loads loans that are on the marketplace, and not the entire history.
-     */
-    private static final Select SELECT = new Select().greaterThan("nonReservedRemainingInvestment", 0);
+    private static final long[] NO_LONGS = new long[0];
     private final Investor investor;
+    private final AtomicReference<long[]> lastChecked = new AtomicReference<>(NO_LONGS);
 
     public InvestingOperationDescriptor(final Investor investor) {
         this.investor = investor;
@@ -41,13 +36,6 @@ class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor
 
     public InvestingOperationDescriptor() {
         this(null);
-    }
-
-    private static boolean isActionable(final LoanDescriptor loanDescriptor) {
-        final OffsetDateTime now = DateUtil.offsetNow();
-        return loanDescriptor.getLoanCaptchaProtectionEndDateTime()
-                .map(d -> d.isBefore(now))
-                .orElse(true);
     }
 
     @Override
@@ -61,11 +49,8 @@ class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor
     }
 
     @Override
-    public Stream<LoanDescriptor> readMarketplace(final Tenant tenant) {
-        return tenant.call(zonky -> zonky.getAvailableLoans(SELECT))
-                .filter(l -> !l.getMyInvestment().isPresent()) // re-investing would fail
-                .map(LoanDescriptor::new)
-                .filter(InvestingOperationDescriptor::isActionable);
+    public MarketplaceAccessor<LoanDescriptor> newMarketplaceAccessor(final Tenant tenant) {
+        return new PrimaryMarketplaceAccessor(tenant, lastChecked::getAndSet);
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
@@ -20,15 +20,15 @@ import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.strategies.InvestmentStrategy;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.common.tenant.Tenant;
 
 class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor, InvestmentStrategy> {
 
-    private static final long[] NO_LONGS = new long[0];
     private final Investor investor;
-    private final AtomicReference<long[]> lastChecked = new AtomicReference<>(NO_LONGS);
+    private final AtomicReference<LastPublishedLoan> lastChecked = new AtomicReference<>(null);
 
     public InvestingOperationDescriptor(final Investor investor) {
         this.investor = investor;

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
@@ -18,10 +18,15 @@ package com.github.robozonky.app.daemon;
 
 import java.util.Collection;
 
+/**
+ * The purpose of implementations of this interface is that marketplace checks are coupled to information about latest
+ * updates to those marketplaces. Each instance of an implementing class may decide to cache the marketplace during
+ * {@link #hasUpdates()} and only ever return that in {@link #getMarketplace()}.
+ * @param <T> Type of the entity coming from the marketplace.
+ */
 interface MarketplaceAccessor<T> {
 
     Collection<T> getMarketplace();
 
     boolean hasUpdates();
-
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
@@ -16,23 +16,12 @@
 
 package com.github.robozonky.app.daemon;
 
-import java.math.BigDecimal;
-import java.util.Optional;
+import java.util.Collection;
 
-import com.github.robozonky.common.tenant.Tenant;
+interface MarketplaceAccessor<T> {
 
-interface OperationDescriptor<T, S> {
+    Collection<T> getMarketplace();
 
-    boolean isEnabled(final Tenant tenant);
-
-    Optional<S> getStrategy(final Tenant tenant);
-
-    MarketplaceAccessor<T> newMarketplaceAccessor(final Tenant tenant);
-
-    BigDecimal getMinimumBalance(final Tenant tenant);
-
-    long identify(final T descriptor);
-
-    Operation<T, S> getOperation();
+    boolean hasUpdates();
 
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -19,7 +19,7 @@ package com.github.robozonky.app.daemon;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import com.github.robozonky.api.remote.entities.LastPublishedLoan;
@@ -39,10 +39,9 @@ final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescri
      */
     private static final Select SELECT = new Select().greaterThan("nonReservedRemainingInvestment", 0);
     private final Tenant tenant;
-    private final Function<LastPublishedLoan, LastPublishedLoan> stateAccessor;
+    private final UnaryOperator<LastPublishedLoan> stateAccessor;
 
-    public PrimaryMarketplaceAccessor(final Tenant tenant,
-                                      final Function<LastPublishedLoan, LastPublishedLoan> stateAccessor) {
+    public PrimaryMarketplaceAccessor(final Tenant tenant, final UnaryOperator<LastPublishedLoan> stateAccessor) {
         this.tenant = tenant;
         this.stateAccessor = stateAccessor;
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.strategies.LoanDescriptor;
+import com.github.robozonky.common.remote.Select;
+import com.github.robozonky.common.tenant.Tenant;
+import com.github.robozonky.internal.util.DateUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescriptor> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    /**
+     * Will make sure that the endpoint only loads loans that are on the marketplace, and not the entire history.
+     */
+    private static final Select SELECT = new Select().greaterThan("nonReservedRemainingInvestment", 0);
+    private final Tenant tenant;
+    private final Function<long[], long[]> lastChecked;
+    private final AtomicReference<Collection<LoanDescriptor>> marketplace = new AtomicReference<>();
+
+    public PrimaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter) {
+        this.tenant = tenant;
+        this.lastChecked = lastCheckedSetter;
+    }
+
+    private static boolean contains(final long toFind, final long... original) {
+        for (final long j : original) {
+            if (j == toFind) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean hasAdditions(final long[] current, final long... original) {
+        if (current.length == 0) {
+            return false;
+        } else if (current.length > original.length) {
+            return true;
+        }
+        for (final long i : current) {
+            final boolean found = contains(i, original);
+            if (!found) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isActionable(final LoanDescriptor loanDescriptor) {
+        final OffsetDateTime now = DateUtil.offsetNow();
+        return loanDescriptor.getLoanCaptchaProtectionEndDateTime()
+                .map(d -> d.isBefore(now))
+                .orElse(true);
+    }
+
+    /**
+     * In order to not have to run the strategy over a marketplace and save CPU cycles, we need to know if the
+     * marketplace changed since the last time this method was called.
+     * @param marketplace Present contents of the marketplace.
+     * @return Returning true triggers evaluation of the strategy.
+     */
+    private boolean hasMarketplaceUpdates(final Collection<LoanDescriptor> marketplace) {
+        final long[] idsFromMarketplace = marketplace.stream().mapToLong(p -> p.item().getId()).toArray();
+        final long[] presentWhenLastChecked = lastChecked.apply(idsFromMarketplace);
+        return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
+    }
+
+    private Stream<LoanDescriptor> readMarketplace() {
+        return tenant.call(zonky -> zonky.getAvailableLoans(SELECT))
+                .filter(l -> !l.getMyInvestment().isPresent()) // re-investing would fail
+                .map(LoanDescriptor::new)
+                .filter(PrimaryMarketplaceAccessor::isActionable);
+    }
+
+    @Override
+    public Collection<LoanDescriptor> getMarketplace() {
+        return marketplace.updateAndGet(old -> {
+            if (old != null) {
+                return old;
+            }
+            return readMarketplace().collect(Collectors.toList());
+        });
+    }
+
+    @Override
+    public boolean hasUpdates() {
+        return hasMarketplaceUpdates(getMarketplace());
+    }
+}

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -18,56 +18,30 @@ package com.github.robozonky.app.daemon;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.common.remote.Select;
+import com.github.robozonky.common.remote.Zonky;
 import com.github.robozonky.common.tenant.Tenant;
 import com.github.robozonky.internal.util.DateUtil;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescriptor> {
 
-    private static final Logger LOGGER = LogManager.getLogger();
     /**
      * Will make sure that the endpoint only loads loans that are on the marketplace, and not the entire history.
      */
     private static final Select SELECT = new Select().greaterThan("nonReservedRemainingInvestment", 0);
     private final Tenant tenant;
-    private final Function<long[], long[]> lastChecked;
-    private final AtomicReference<Collection<LoanDescriptor>> marketplace = new AtomicReference<>();
+    private final Function<LastPublishedLoan, LastPublishedLoan> lastChecked;
 
-    public PrimaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter) {
+    public PrimaryMarketplaceAccessor(final Tenant tenant,
+                                      final Function<LastPublishedLoan, LastPublishedLoan> lastCheckedSetter) {
         this.tenant = tenant;
         this.lastChecked = lastCheckedSetter;
-    }
-
-    private static boolean contains(final long toFind, final long... original) {
-        for (final long j : original) {
-            if (j == toFind) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static boolean hasAdditions(final long[] current, final long... original) {
-        if (current.length == 0) {
-            return false;
-        } else if (current.length > original.length) {
-            return true;
-        }
-        for (final long i : current) {
-            final boolean found = contains(i, original);
-            if (!found) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static boolean isActionable(final LoanDescriptor loanDescriptor) {
@@ -77,37 +51,19 @@ final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescri
                 .orElse(true);
     }
 
-    /**
-     * In order to not have to run the strategy over a marketplace and save CPU cycles, we need to know if the
-     * marketplace changed since the last time this method was called.
-     * @param marketplace Present contents of the marketplace.
-     * @return Returning true triggers evaluation of the strategy.
-     */
-    private boolean hasMarketplaceUpdates(final Collection<LoanDescriptor> marketplace) {
-        final long[] idsFromMarketplace = marketplace.stream().mapToLong(p -> p.item().getId()).toArray();
-        final long[] presentWhenLastChecked = lastChecked.apply(idsFromMarketplace);
-        return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
-    }
-
-    private Stream<LoanDescriptor> readMarketplace() {
+    @Override
+    public Collection<LoanDescriptor> getMarketplace() {
         return tenant.call(zonky -> zonky.getAvailableLoans(SELECT))
                 .filter(l -> !l.getMyInvestment().isPresent()) // re-investing would fail
                 .map(LoanDescriptor::new)
-                .filter(PrimaryMarketplaceAccessor::isActionable);
-    }
-
-    @Override
-    public Collection<LoanDescriptor> getMarketplace() {
-        return marketplace.updateAndGet(old -> {
-            if (old != null) {
-                return old;
-            }
-            return readMarketplace().collect(Collectors.toList());
-        });
+                .filter(PrimaryMarketplaceAccessor::isActionable)
+                .collect(Collectors.toList());
     }
 
     @Override
     public boolean hasUpdates() {
-        return hasMarketplaceUpdates(getMarketplace());
+        final LastPublishedLoan current = tenant.call(Zonky::getLastPublishedLoanInfo);
+        final LastPublishedLoan previous = lastChecked.apply(current);
+        return !Objects.equals(previous, current);
     }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -39,12 +39,12 @@ final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescri
      */
     private static final Select SELECT = new Select().greaterThan("nonReservedRemainingInvestment", 0);
     private final Tenant tenant;
-    private final Function<LastPublishedLoan, LastPublishedLoan> lastChecked;
+    private final Function<LastPublishedLoan, LastPublishedLoan> stateAccessor;
 
     public PrimaryMarketplaceAccessor(final Tenant tenant,
-                                      final Function<LastPublishedLoan, LastPublishedLoan> lastCheckedSetter) {
+                                      final Function<LastPublishedLoan, LastPublishedLoan> stateAccessor) {
         this.tenant = tenant;
-        this.lastChecked = lastCheckedSetter;
+        this.stateAccessor = stateAccessor;
     }
 
     private static boolean isActionable(final LoanDescriptor loanDescriptor) {
@@ -67,7 +67,7 @@ final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescri
     public boolean hasUpdates() {
         try {
             final LastPublishedLoan current = tenant.call(Zonky::getLastPublishedLoanInfo);
-            final LastPublishedLoan previous = lastChecked.apply(current);
+            final LastPublishedLoan previous = stateAccessor.apply(current);
             return !Objects.equals(previous, current);
         } catch (final Exception ex) {
             LOGGER.debug("Zonky marketplace status endpoint failed, forcing live marketplace check.", ex);

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
@@ -18,24 +18,16 @@ package com.github.robozonky.app.daemon;
 
 import java.math.BigDecimal;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicReference;
 
-import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.ParticipationDescriptor;
 import com.github.robozonky.api.strategies.PurchaseStrategy;
-import com.github.robozonky.app.tenant.SoldParticipationCache;
-import com.github.robozonky.common.remote.Select;
 import com.github.robozonky.common.tenant.Tenant;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 class PurchasingOperationDescriptor implements OperationDescriptor<ParticipationDescriptor, PurchaseStrategy> {
 
-    private static final Logger LOGGER = LogManager.getLogger(PurchasingOperationDescriptor.class);
-
-    private static ParticipationDescriptor toDescriptor(final Participation p, final Tenant tenant) {
-        return new ParticipationDescriptor(p, () -> tenant.getLoan(p.getLoanId()));
-    }
+    private static final long[] NO_LONGS = new long[0];
+    private final AtomicReference<long[]> lastChecked = new AtomicReference<>(NO_LONGS);
 
     @Override
     public boolean isEnabled(final Tenant tenant) {
@@ -48,20 +40,8 @@ class PurchasingOperationDescriptor implements OperationDescriptor<Participation
     }
 
     @Override
-    public Stream<ParticipationDescriptor> readMarketplace(final Tenant tenant) {
-        final long balance = tenant.getPortfolio().getBalance().longValue();
-        final Select s = new Select()
-                .lessThanOrEquals("remainingPrincipal", balance)
-                .equalsPlain("willNotExceedLoanInvestmentLimit", "true");
-        final SoldParticipationCache cache = SoldParticipationCache.forTenant(tenant);
-        return tenant.call(zonky -> zonky.getAvailableParticipations(s))
-                .filter(p -> { // never re-purchase what was once sold
-                    final int loanId = p.getLoanId();
-                    final boolean wasSoldBefore = cache.wasOnceSold(loanId);
-                    LOGGER.debug("Loan #{} already sold before, ignoring: {}.", loanId, wasSoldBefore);
-                    return !wasSoldBefore;
-                })
-                .map(p -> toDescriptor(p, tenant));
+    public MarketplaceAccessor<ParticipationDescriptor> newMarketplaceAccessor(final Tenant tenant) {
+        return new SecondaryMarketplaceAccessor(tenant, lastChecked::getAndSet);
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
@@ -41,7 +41,7 @@ class PurchasingOperationDescriptor implements OperationDescriptor<Participation
 
     @Override
     public MarketplaceAccessor<ParticipationDescriptor> newMarketplaceAccessor(final Tenant tenant) {
-        return new SecondaryMarketplaceAccessor(tenant, lastChecked::getAndSet);
+        return new SecondaryMarketplaceAccessor(tenant, lastChecked::getAndSet, this::identify);
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.remote.entities.Participation;
+import com.github.robozonky.api.strategies.ParticipationDescriptor;
+import com.github.robozonky.app.tenant.SoldParticipationCache;
+import com.github.robozonky.common.remote.Select;
+import com.github.robozonky.common.tenant.Tenant;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<ParticipationDescriptor> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final Tenant tenant;
+    private final Function<long[], long[]> lastChecked;
+    private final AtomicReference<Collection<ParticipationDescriptor>> marketplace = new AtomicReference<>();
+
+    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter) {
+        this.tenant = tenant;
+        this.lastChecked = lastCheckedSetter;
+    }
+
+    private static boolean contains(final long toFind, final long... original) {
+        for (final long j : original) {
+            if (j == toFind) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean hasAdditions(final long[] current, final long... original) {
+        if (current.length == 0) {
+            return false;
+        } else if (current.length > original.length) {
+            return true;
+        }
+        for (final long i : current) {
+            final boolean found = contains(i, original);
+            if (!found) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ParticipationDescriptor toDescriptor(final Participation p, final Tenant tenant) {
+        return new ParticipationDescriptor(p, () -> tenant.getLoan(p.getLoanId()));
+    }
+
+    /**
+     * In order to not have to run the strategy over a marketplace and save CPU cycles, we need to know if the
+     * marketplace changed since the last time this method was called.
+     * @param marketplace Present contents of the marketplace.
+     * @return Returning true triggers evaluation of the strategy.
+     */
+    private boolean hasMarketplaceUpdates(final Collection<ParticipationDescriptor> marketplace) {
+        final long[] idsFromMarketplace = marketplace.stream().mapToLong(p -> p.item().getId()).toArray();
+        final long[] presentWhenLastChecked = lastChecked.apply(idsFromMarketplace);
+        return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
+    }
+
+    private Stream<ParticipationDescriptor> readMarketplace() {
+        final long balance = tenant.getPortfolio().getBalance().longValue();
+        final Select s = new Select()
+                .lessThanOrEquals("remainingPrincipal", balance)
+                .equalsPlain("willNotExceedLoanInvestmentLimit", "true");
+        final SoldParticipationCache cache = SoldParticipationCache.forTenant(tenant);
+        return tenant.call(zonky -> zonky.getAvailableParticipations(s))
+                .filter(p -> { // never re-purchase what was once sold
+                    final int loanId = p.getLoanId();
+                    final boolean wasSoldBefore = cache.wasOnceSold(loanId);
+                    LOGGER.debug("Loan #{} already sold before, ignoring: {}.", loanId, wasSoldBefore);
+                    return !wasSoldBefore;
+                })
+                .map(p -> toDescriptor(p, tenant));
+    }
+
+    @Override
+    public Collection<ParticipationDescriptor> getMarketplace() {
+        return marketplace.updateAndGet(old -> {
+            if (old != null) {
+                return old;
+            }
+            return readMarketplace().collect(Collectors.toList());
+        });
+    }
+
+    @Override
+    public boolean hasUpdates() {
+        return hasMarketplaceUpdates(getMarketplace());
+    }
+}

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
@@ -18,8 +18,8 @@ package com.github.robozonky.app.daemon;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.function.ToLongFunction;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,11 +36,11 @@ final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<Particip
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final Tenant tenant;
-    private final Function<long[], long[]> stateAccessor;
+    private final UnaryOperator<long[]> stateAccessor;
     private final ToLongFunction<ParticipationDescriptor> identifier;
     private final AtomicReference<Collection<ParticipationDescriptor>> marketplace = new AtomicReference<>();
 
-    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> stateAccessor,
+    public SecondaryMarketplaceAccessor(final Tenant tenant, final UnaryOperator<long[]> stateAccessor,
                                         final ToLongFunction<ParticipationDescriptor> identifier) {
         this.tenant = tenant;
         this.stateAccessor = stateAccessor;

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
@@ -19,6 +19,7 @@ package com.github.robozonky.app.daemon;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,11 +37,14 @@ final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<Particip
 
     private final Tenant tenant;
     private final Function<long[], long[]> lastChecked;
+    private final ToLongFunction<ParticipationDescriptor> identifier;
     private final AtomicReference<Collection<ParticipationDescriptor>> marketplace = new AtomicReference<>();
 
-    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter) {
+    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter,
+                                        final ToLongFunction<ParticipationDescriptor> identifier) {
         this.tenant = tenant;
         this.lastChecked = lastCheckedSetter;
+        this.identifier = identifier;
     }
 
     private static boolean contains(final long toFind, final long... original) {
@@ -78,7 +82,7 @@ final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<Particip
      * @return Returning true triggers evaluation of the strategy.
      */
     private boolean hasMarketplaceUpdates(final Collection<ParticipationDescriptor> marketplace) {
-        final long[] idsFromMarketplace = marketplace.stream().mapToLong(p -> p.item().getId()).toArray();
+        final long[] idsFromMarketplace = marketplace.stream().mapToLong(identifier).toArray();
         final long[] presentWhenLastChecked = lastChecked.apply(idsFromMarketplace);
         return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
@@ -36,14 +36,14 @@ final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<Particip
     private static final Logger LOGGER = LogManager.getLogger();
 
     private final Tenant tenant;
-    private final Function<long[], long[]> lastChecked;
+    private final Function<long[], long[]> stateAccessor;
     private final ToLongFunction<ParticipationDescriptor> identifier;
     private final AtomicReference<Collection<ParticipationDescriptor>> marketplace = new AtomicReference<>();
 
-    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> lastCheckedSetter,
+    public SecondaryMarketplaceAccessor(final Tenant tenant, final Function<long[], long[]> stateAccessor,
                                         final ToLongFunction<ParticipationDescriptor> identifier) {
         this.tenant = tenant;
-        this.lastChecked = lastCheckedSetter;
+        this.stateAccessor = stateAccessor;
         this.identifier = identifier;
     }
 
@@ -83,7 +83,7 @@ final class SecondaryMarketplaceAccessor implements MarketplaceAccessor<Particip
      */
     private boolean hasMarketplaceUpdates(final Collection<ParticipationDescriptor> marketplace) {
         final long[] idsFromMarketplace = marketplace.stream().mapToLong(identifier).toArray();
-        final long[] presentWhenLastChecked = lastChecked.apply(idsFromMarketplace);
+        final long[] presentWhenLastChecked = stateAccessor.apply(idsFromMarketplace);
         return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/StrategyExecutor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/StrategyExecutor.java
@@ -62,10 +62,6 @@ class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
     }
 
     private boolean skipStrategyEvaluation(final MarketplaceAccessor<T> marketplace) {
-        if (needsToForceMarketplaceCheck()) {
-            logger.debug("Forcing a periodic live marketplace checked.");
-            return false;
-        }
         final BigDecimal currentBalance = tenant.getPortfolio().getBalance();
         final BigDecimal lastCheckedBalance = balanceWhenLastChecked.getAndSet(currentBalance);
         final boolean balanceChangedMeaningfully = isBiggerThan(currentBalance, lastCheckedBalance);
@@ -74,6 +70,9 @@ class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
             return false;
         } else if (marketplace.hasUpdates()) {
             logger.debug("Waking up due to a change in marketplace.");
+            return false;
+        } else if (needsToForceMarketplaceCheck()) {
+            logger.debug("Forcing a periodic live marketplace check.");
             return false;
         } else {
             logger.debug("Asleep as there was no change since last checked.");
@@ -94,7 +93,7 @@ class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
         }
         final Collection<T> marketplace = marketplaceAccessor.getMarketplace();
         if (marketplace.isEmpty()) {
-            logger.debug("Asleep as the marketplace is empty.");
+            logger.debug("Marketplace is empty.");
             return Collections.emptyList();
         }
         logger.trace("Processing {} items from the marketplace.", marketplace.size());

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/StrategyExecutor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/StrategyExecutor.java
@@ -21,8 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import java.util.function.ToLongFunction;
-import java.util.stream.Collectors;
 
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
 import com.github.robozonky.api.strategies.InvestmentStrategy;
@@ -35,11 +33,9 @@ import org.apache.logging.log4j.Logger;
 
 class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
 
-    private static final long[] NO_LONGS = new long[0];
     private final Logger logger = LogManager.getLogger(getClass());
     private final PowerTenant tenant;
     private final AtomicReference<BigDecimal> balanceWhenLastChecked = new AtomicReference<>(BigDecimal.ZERO);
-    private final AtomicReference<long[]> lastChecked = new AtomicReference<>(NO_LONGS);
     private final OperationDescriptor<T, S> operationDescriptor;
 
     StrategyExecutor(final PowerTenant tenant, final OperationDescriptor<T, S> operationDescriptor) {
@@ -60,42 +56,14 @@ class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
         return left.compareTo(right) > 0;
     }
 
-    private static boolean contains(final long toFind, final long... original) {
-        for (final long j : original) {
-            if (j == toFind) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static boolean hasAdditions(final long[] current, final long... original) {
-        if (current.length == 0) {
-            return false;
-        } else if (current.length > original.length) {
-            return true;
-        }
-        for (final long i : current) {
-            final boolean found = contains(i, original);
-            if (!found) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean skipStrategyEvaluation(final Collection<T> marketplace) {
-        if (marketplace.isEmpty()) {
-            logger.debug("Asleep as the marketplace is empty.");
-            return true;
-        }
+    private boolean skipStrategyEvaluation(final MarketplaceAccessor<T> marketplace) {
         final BigDecimal currentBalance = tenant.getPortfolio().getBalance();
         final BigDecimal lastCheckedBalance = balanceWhenLastChecked.getAndSet(currentBalance);
         final boolean balanceChangedMeaningfully = isBiggerThan(currentBalance, lastCheckedBalance);
         if (balanceChangedMeaningfully) {
             logger.debug("Waking up due to a balance increase.");
             return false;
-        } else if (hasMarketplaceUpdates(marketplace, operationDescriptor::identify)) {
+        } else if (marketplace.hasUpdates()) {
             logger.debug("Waking up due to a change in marketplace.");
             return false;
         } else {
@@ -104,21 +72,14 @@ class StrategyExecutor<T, S> implements Supplier<Collection<Investment>> {
         }
     }
 
-    /**
-     * In order to not have to run the strategy over a marketplace and save CPU cycles, we need to know if the
-     * marketplace changed since the last time this method was called.
-     * @param marketplace Present contents of the marketplace.
-     * @return Returning true triggers evaluation of the strategy.
-     */
-    private boolean hasMarketplaceUpdates(final Collection<T> marketplace, final ToLongFunction<T> idSupplier) {
-        final long[] idsFromMarketplace = marketplace.stream().mapToLong(idSupplier).toArray();
-        final long[] presentWhenLastChecked = lastChecked.getAndSet(idsFromMarketplace);
-        return hasAdditions(idsFromMarketplace, presentWhenLastChecked);
-    }
-
     private Collection<Investment> invest(final S strategy) {
-        final Collection<T> marketplace = operationDescriptor.readMarketplace(tenant).collect(Collectors.toList());
-        if (skipStrategyEvaluation(marketplace)) {
+        final MarketplaceAccessor<T> marketplaceAccessor = operationDescriptor.newMarketplaceAccessor(tenant);
+        if (skipStrategyEvaluation(marketplaceAccessor)) {
+            return Collections.emptyList();
+        }
+        final Collection<T> marketplace = marketplaceAccessor.getMarketplace();
+        if (marketplace.isEmpty()) {
+            logger.debug("Asleep as the marketplace is empty.");
             return Collections.emptyList();
         }
         logger.trace("Processing {} items from the marketplace.", marketplace.size());

--- a/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -136,7 +135,5 @@ class CommandLineTest extends AbstractRoboZonkyTest {
         assertThat(cli.getNotificationConfigLocation()).isEmpty();
         assertThat(cli.getName()).isEqualTo("Unnamed");
         assertThat(cli.isDryRunEnabled()).isFalse();
-        assertThat(cli.getPrimaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
-        assertThat(cli.getSecondaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -135,5 +136,7 @@ class CommandLineTest extends AbstractRoboZonkyTest {
         assertThat(cli.getNotificationConfigLocation()).isEmpty();
         assertThat(cli.getName()).isEqualTo("Unnamed");
         assertThat(cli.isDryRunEnabled()).isFalse();
+        assertThat(cli.getPrimaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
+        assertThat(cli.getSecondaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/configuration/CommandLineTest.java
@@ -136,7 +136,6 @@ class CommandLineTest extends AbstractRoboZonkyTest {
         assertThat(cli.getNotificationConfigLocation()).isEmpty();
         assertThat(cli.getName()).isEqualTo("Unnamed");
         assertThat(cli.isDryRunEnabled()).isFalse();
-        assertThat(cli.getPrimaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
         assertThat(cli.getSecondaryMarketplaceCheckDelay()).isEqualTo(Duration.ofSeconds(1));
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class DaemonInvestmentModeTest extends AbstractZonkyLeveragingTest {
         final PowerTenant a = mockTenant(harmlessZonky(10_000), true);
         final Investor b = Investor.build(a);
         final ExecutorService e = Executors.newFixedThreadPool(1);
-        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b, ONE_SECOND, ONE_SECOND))) {
+        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b))) {
             assertThat(d.getSessionInfo()).isSameAs(a.getSessionInfo());
             doNothing().when(d).submit(any(), any(), any(), any());
             final Future<ReturnCode> f = e.submit(() -> d.apply(lifecycle)); // will block

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
@@ -45,7 +45,7 @@ class DaemonInvestmentModeTest extends AbstractZonkyLeveragingTest {
         final PowerTenant a = mockTenant(harmlessZonky(10_000), true);
         final Investor b = Investor.build(a);
         final ExecutorService e = Executors.newFixedThreadPool(1);
-        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b, ONE_SECOND, ONE_SECOND))) {
+        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b, ONE_SECOND))) {
             assertThat(d.getSessionInfo()).isSameAs(a.getSessionInfo());
             doNothing().when(d).submit(any(), any(), any(), any());
             final Future<ReturnCode> f = e.submit(() -> d.apply(lifecycle)); // will block

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonInvestmentModeTest.java
@@ -45,7 +45,7 @@ class DaemonInvestmentModeTest extends AbstractZonkyLeveragingTest {
         final PowerTenant a = mockTenant(harmlessZonky(10_000), true);
         final Investor b = Investor.build(a);
         final ExecutorService e = Executors.newFixedThreadPool(1);
-        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b))) {
+        try (final DaemonInvestmentMode d = spy(new DaemonInvestmentMode(a, b, ONE_SECOND, ONE_SECOND))) {
             assertThat(d.getSessionInfo()).isSameAs(a.getSessionInfo());
             doNothing().when(d).submit(any(), any(), any(), any());
             final Future<ReturnCode> f = e.submit(() -> d.apply(lifecycle)); // will block

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingOperationDescriptionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingOperationDescriptionTest.java
@@ -16,12 +16,16 @@
 
 package com.github.robozonky.app.daemon;
 
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import com.github.robozonky.common.remote.Zonky;
+import com.github.robozonky.common.tenant.Tenant;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class InvestingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
 
@@ -32,4 +36,17 @@ class InvestingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
         final LoanDescriptor ld = new LoanDescriptor(l);
         assertThat(d.identify(ld)).isEqualTo(l.getId());
     }
+
+    @Test
+    void freshAccessorEveryTimeButTheyShareState() {
+        final Zonky z = harmlessZonky(10_000);
+        when(z.getLastPublishedLoanInfo()).thenReturn(mock(LastPublishedLoan.class));
+        final Tenant t = mockTenant(z);
+        final InvestingOperationDescriptor d = new InvestingOperationDescriptor();
+        final MarketplaceAccessor<LoanDescriptor> a1 = d.newMarketplaceAccessor(t);
+        assertThat(a1.hasUpdates()).isTrue();
+        final MarketplaceAccessor<LoanDescriptor> a2 = d.newMarketplaceAccessor(t);
+        assertThat(a2.hasUpdates()).isFalse();
+    }
+
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingOperationDescriptionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingOperationDescriptionTest.java
@@ -1,18 +1,27 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.robozonky.app.daemon;
 
-import java.util.stream.Stream;
-
-import com.github.robozonky.api.remote.entities.MyInvestment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
-import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
-import com.github.robozonky.common.remote.Zonky;
-import com.github.robozonky.common.tenant.Tenant;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class InvestingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
 
@@ -23,27 +32,4 @@ class InvestingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
         final LoanDescriptor ld = new LoanDescriptor(l);
         assertThat(d.identify(ld)).isEqualTo(l.getId());
     }
-
-    @Test
-    void eliminatesUselessLoans() {
-        final Loan alreadyInvested = Loan.custom()
-                .setRating(Rating.B)
-                .setNonReservedRemainingInvestment(1)
-                .setMyInvestment(mock(MyInvestment.class))
-                .build();
-        final Loan normal = Loan.custom()
-                .setRating(Rating.A)
-                .setNonReservedRemainingInvestment(1)
-                .build();
-        final InvestingOperationDescriptor d = new InvestingOperationDescriptor();
-        final Zonky zonky = harmlessZonky(10_000);
-        when(zonky.getAvailableLoans(any())).thenReturn(Stream.of(alreadyInvested, normal));
-        final Tenant tenant = mockTenant(zonky);
-        final Stream<LoanDescriptor> ld = d.readMarketplace(tenant);
-        assertThat(ld).hasSize(1)
-                .element(0)
-                .extracting(LoanDescriptor::item)
-                .isSameAs(normal);
-    }
-
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.remote.entities.MyInvestment;
+import com.github.robozonky.api.remote.entities.sanitized.Loan;
+import com.github.robozonky.api.remote.enums.Rating;
+import com.github.robozonky.api.strategies.LoanDescriptor;
+import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import com.github.robozonky.common.remote.Zonky;
+import com.github.robozonky.common.tenant.Tenant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PrimaryMarketplaceAccessorTest extends AbstractZonkyLeveragingTest {
+
+    @Test
+    void eliminatesUselessLoans() {
+        final Loan alreadyInvested = Loan.custom()
+                .setRating(Rating.B)
+                .setNonReservedRemainingInvestment(1)
+                .setMyInvestment(mock(MyInvestment.class))
+                .build();
+        final Loan normal = Loan.custom()
+                .setRating(Rating.A)
+                .setNonReservedRemainingInvestment(1)
+                .build();
+        final Zonky zonky = harmlessZonky(10_000);
+        when(zonky.getAvailableLoans(any())).thenReturn(Stream.of(alreadyInvested, normal));
+        final Tenant tenant = mockTenant(zonky);
+        final MarketplaceAccessor<LoanDescriptor> d = new PrimaryMarketplaceAccessor(tenant, Function.identity());
+        final Collection<LoanDescriptor> ld = d.getMarketplace();
+        assertThat(ld).hasSize(1)
+                .element(0)
+                .extracting(LoanDescriptor::item)
+                .isSameAs(normal);
+    }
+}

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessorTest.java
@@ -17,9 +17,11 @@
 package com.github.robozonky.app.daemon;
 
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.remote.entities.MyInvestment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.remote.enums.Rating;
@@ -55,5 +57,27 @@ class PrimaryMarketplaceAccessorTest extends AbstractZonkyLeveragingTest {
                 .element(0)
                 .extracting(LoanDescriptor::item)
                 .isSameAs(normal);
+    }
+
+    @Test
+    void detectsUpdates() {
+        final Zonky z = harmlessZonky(10_000);
+        when(z.getLastPublishedLoanInfo()).thenReturn(mock(LastPublishedLoan.class));
+        final Tenant t = mockTenant(z);
+        final AtomicReference<LastPublishedLoan> state = new AtomicReference<>(null);
+        final MarketplaceAccessor<LoanDescriptor> a = new PrimaryMarketplaceAccessor(t, state::getAndSet);
+        assertThat(a.hasUpdates()).isTrue(); // detect update, store present state
+        assertThat(a.hasUpdates()).isFalse(); // state stays the same, no update
+    }
+
+    @Test
+    void failsDetection() {
+        final Zonky z = harmlessZonky(10_000);
+        when(z.getLastPublishedLoanInfo()).thenThrow(IllegalStateException.class);
+        final Tenant t = mockTenant(z);
+        final AtomicReference<LastPublishedLoan> state = new AtomicReference<>(null);
+        final MarketplaceAccessor<LoanDescriptor> a = new PrimaryMarketplaceAccessor(t, state::getAndSet);
+        assertThat(a.hasUpdates()).isTrue();
+        assertThat(a.hasUpdates()).isTrue();
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptionTest.java
@@ -1,13 +1,25 @@
-package com.github.robozonky.app.daemon;
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import java.util.stream.Stream;
+package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.strategies.ParticipationDescriptor;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
-import com.github.robozonky.common.remote.Zonky;
-import com.github.robozonky.common.tenant.Tenant;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -23,21 +35,6 @@ class PurchasingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
         final Loan l = Loan.custom().build();
         final ParticipationDescriptor pd = new ParticipationDescriptor(p, () -> l);
         assertThat(d.identify(pd)).isEqualTo(1);
-    }
-
-    @Test
-    void readsMarketplace() {
-        final Participation p = mock(Participation.class);
-        when(p.getId()).thenReturn(1l);
-        final PurchasingOperationDescriptor d = new PurchasingOperationDescriptor();
-        final Zonky zonky = harmlessZonky(10_000);
-        when(zonky.getAvailableParticipations(any())).thenReturn(Stream.of(p));
-        final Tenant tenant = mockTenant(zonky);
-        final Stream<ParticipationDescriptor> ld = d.readMarketplace(tenant);
-        assertThat(ld).hasSize(1)
-                .element(0)
-                .extracting(ParticipationDescriptor::item)
-                .isSameAs(p);
     }
 
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptionTest.java
@@ -16,10 +16,14 @@
 
 package com.github.robozonky.app.daemon;
 
+import java.util.stream.Stream;
+
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.strategies.ParticipationDescriptor;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import com.github.robozonky.common.remote.Zonky;
+import com.github.robozonky.common.tenant.Tenant;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -35,6 +39,20 @@ class PurchasingOperationDescriptionTest extends AbstractZonkyLeveragingTest {
         final Loan l = Loan.custom().build();
         final ParticipationDescriptor pd = new ParticipationDescriptor(p, () -> l);
         assertThat(d.identify(pd)).isEqualTo(1);
+    }
+
+    @Test
+    void freshAccessorEveryTimeButTheyShareState() {
+        final Participation p = mock(Participation.class);
+        when(p.getId()).thenReturn(1l);
+        final Zonky z = harmlessZonky(10_000);
+        when(z.getAvailableParticipations(any())).thenAnswer(i -> Stream.of(p));
+        final Tenant t = mockTenant(z);
+        final PurchasingOperationDescriptor d = new PurchasingOperationDescriptor();
+        final MarketplaceAccessor<ParticipationDescriptor> a1 = d.newMarketplaceAccessor(t);
+        assertThat(a1.hasUpdates()).isTrue();
+        final MarketplaceAccessor<ParticipationDescriptor> a2 = d.newMarketplaceAccessor(t);
+        assertThat(a2.hasUpdates()).isFalse();
     }
 
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.app.daemon;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.remote.entities.Participation;
+import com.github.robozonky.api.strategies.ParticipationDescriptor;
+import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import com.github.robozonky.common.remote.Zonky;
+import com.github.robozonky.common.tenant.Tenant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SecondaryMarketplaceAccessorTest extends AbstractZonkyLeveragingTest {
+
+    @Test
+    void hasAdditions() {
+        final long[] original = new long[]{1};
+        final long[] updated = new long[]{1, 2};
+        assertSoftly(softly -> {
+            softly.assertThat(SecondaryMarketplaceAccessor.hasAdditions(new long[0], original)).isFalse();
+            softly.assertThat(SecondaryMarketplaceAccessor.hasAdditions(updated, original)).isTrue();
+            softly.assertThat(SecondaryMarketplaceAccessor.hasAdditions(updated, original)).isTrue();
+            softly.assertThat(SecondaryMarketplaceAccessor.hasAdditions(original, original)).isFalse();
+        });
+    }
+
+    @Test
+    void readsMarketplace() {
+        final Participation p = mock(Participation.class);
+        when(p.getId()).thenReturn(1l);
+        final Zonky zonky = harmlessZonky(10_000);
+        when(zonky.getAvailableParticipations(any())).thenReturn(Stream.of(p));
+        final Tenant tenant = mockTenant(zonky);
+        final MarketplaceAccessor<ParticipationDescriptor> d = new SecondaryMarketplaceAccessor(tenant,
+                                                                                                Function.identity(),
+                                                                                                f -> f.item().getId());
+        final Collection<ParticipationDescriptor> ld = d.getMarketplace();
+        assertThat(ld).hasSize(1)
+                .element(0)
+                .extracting(ParticipationDescriptor::item)
+                .isSameAs(p);
+    }
+}

--- a/robozonky-common/src/main/java/com/github/robozonky/common/remote/Zonky.java
+++ b/robozonky-common/src/main/java/com/github/robozonky/common/remote/Zonky.java
@@ -33,6 +33,7 @@ import com.github.robozonky.api.remote.PortfolioApi;
 import com.github.robozonky.api.remote.TransactionApi;
 import com.github.robozonky.api.remote.WalletApi;
 import com.github.robozonky.api.remote.entities.BlockedAmount;
+import com.github.robozonky.api.remote.entities.LastPublishedLoan;
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.entities.PurchaseRequest;
 import com.github.robozonky.api.remote.entities.RawDevelopment;
@@ -188,6 +189,10 @@ public class Zonky {
     public Optional<Investment> getInvestmentByLoanId(final int loanId) {
         final Select s = new Select().equals("loan.id", loanId);
         return getInvestments(s).findFirst();
+    }
+
+    public LastPublishedLoan getLastPublishedLoanInfo() {
+        return loanApi.execute(LoanApi::lastPublished);
     }
 
     /**


### PR DESCRIPTION
This is a backwards incompatible change, on account of removing the `-w` and `-ws` command line switches.