### PR TITLE
Only sell investments gradually not to skew the portfolio information

### DIFF
--- a/robozonky-api/src/main/java/com/github/robozonky/api/Ratio.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/Ratio.java
@@ -53,7 +53,7 @@ public final class Ratio extends Number implements Comparable<Ratio> {
 
     @Override
     public String toString() {
-        return percentage.toPlainString() + " %";
+        return raw.toPlainString();
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingJob.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingJob.java
@@ -30,11 +30,11 @@ final class SellingJob implements TenantJob {
 
     @Override
     public Duration repeatEvery() {
-        return Duration.ofDays(1);
+        return Duration.ofHours(2); // to match the remote Zonky portfolio recalc
     }
 
     @Override
     public boolean prioritize() {
-        return true; // this is a key feature of the application and only happens once per day, so prioritize
+        return true; // this is a key feature of the application and only happens occasionally, so prioritize
     }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingThrottle.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingThrottle.java
@@ -1,0 +1,89 @@
+package com.github.robozonky.app.daemon;
+
+import java.math.BigDecimal;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.Ratio;
+import com.github.robozonky.api.remote.enums.Rating;
+import com.github.robozonky.api.strategies.PortfolioOverview;
+import com.github.robozonky.api.strategies.RecommendedInvestment;
+import com.github.robozonky.internal.util.BigDecimalCalculator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The goal of this class is to only sell investments in small amounts, so that the entire {@link PortfolioOverview} is
+ * not destabilized.
+ * <p>
+ * This is necessary, since Zonky only recalculates {@link PortfolioOverview} every 2 hours and investments sold before
+ * the recalculation therefore cause {@link PortfolioOverview} to become out of sync with reality. This throttle will
+ * make sure we only sell so much as to affect the portfolio only by a reasonable amount.
+ */
+final class SellingThrottle
+        implements BiFunction<Stream<RecommendedInvestment>, PortfolioOverview, Stream<RecommendedInvestment>> {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Ratio MAX_SELLOFF_SHARE_PER_RATING = Ratio.fromPercentage(0.5);
+
+    private static Stream<RecommendedInvestment> determineSelloffByRating(final Set<RecommendedInvestment> eligible,
+                                                                          final long maxSelloffSizeInCzk) {
+        if (eligible.isEmpty()) {
+            LOGGER.debug("No investments eligible.");
+            return Stream.empty();
+        }
+        long czkIncluded = 0;
+        final List<RecommendedInvestment> byAmountIncreasing = eligible.stream()
+                .sorted(Comparator.comparing(d -> d.descriptor().item().getRemainingPrincipal()))
+                .collect(Collectors.toList());
+        LOGGER.trace("Eligible investments: {}.", byAmountIncreasing);
+        final Set<RecommendedInvestment> included = new HashSet<>();
+        // find all the investments that can be sold without reaching over the limit, start with the smallest first
+        for (final RecommendedInvestment evaluating : byAmountIncreasing) {
+            final long value = evaluating.descriptor().item().getRemainingPrincipal().longValueExact();
+            final long ifIncluded = czkIncluded + value;
+            if (ifIncluded > maxSelloffSizeInCzk) {
+                continue;
+            }
+            czkIncluded += value;
+            included.add(evaluating);
+        }
+        /*
+         * if no investments can be sold without reaching over the limit, then the portfolio is very small; still, the
+         * user expects us to sell something, so pick the smallest thing we could possibly sell.
+         */
+        if (included.isEmpty()) {
+            final RecommendedInvestment descriptor = byAmountIncreasing.get(0);
+            LOGGER.debug("Will sell one investment: {}.", descriptor);
+            return Stream.of(descriptor);
+        } else {
+            LOGGER.debug("Investments with total value of {} CZK to be sold: {}.", czkIncluded, byAmountIncreasing);
+            return included.stream();
+        }
+    }
+
+    private static long getMaxSelloffValue(final PortfolioOverview portfolioOverview, final Rating rating) {
+        final BigDecimal invested = portfolioOverview.getCzkInvested(rating);
+        final BigDecimal sellable = BigDecimalCalculator.times(invested, MAX_SELLOFF_SHARE_PER_RATING);
+        return sellable.longValueExact();
+    }
+
+    @Override
+    public Stream<RecommendedInvestment> apply(final Stream<RecommendedInvestment> investmentDescriptors,
+                                               final PortfolioOverview portfolioOverview) {
+        final Map<Rating, Set<RecommendedInvestment>> eligible = investmentDescriptors
+                .collect(Collectors.groupingBy(t -> t.descriptor().item().getRating(), Collectors.toSet()));
+        return eligible.entrySet().stream()
+                .flatMap(e -> {
+                    final Rating r = e.getKey();
+                    LOGGER.debug("Processing {} investments.", r);
+                    return determineSelloffByRating(e.getValue(), getMaxSelloffValue(portfolioOverview, r));
+                });
+    }
+}

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SelingThrottleTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SelingThrottleTest.java
@@ -1,0 +1,84 @@
+package com.github.robozonky.app.daemon;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import com.github.robozonky.api.remote.entities.sanitized.Investment;
+import com.github.robozonky.api.remote.enums.Rating;
+import com.github.robozonky.api.strategies.InvestmentDescriptor;
+import com.github.robozonky.api.strategies.PortfolioOverview;
+import com.github.robozonky.api.strategies.RecommendedInvestment;
+import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class SelingThrottleTest extends AbstractZonkyLeveragingTest {
+
+    @Test
+    void picksSmallestOneIfAllOverThreshold() {
+        final Rating rating = Rating.A;
+        final Investment i1 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.TEN)
+                .build();
+        final Investment i2 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.TEN.pow(2))
+                .build();
+        final Investment i3 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.ONE)
+                .build();
+        final PortfolioOverview portfolioOverview = mockPortfolioOverview(10_000);
+        when(portfolioOverview.getCzkInvested(eq(rating))).thenReturn(BigDecimal.TEN);
+        final Stream<RecommendedInvestment> recommendations = Stream.of(i1, i2, i3)
+                .map(i -> new InvestmentDescriptor(i, () -> null))
+                .map(d -> d.recommend(d.item().getRemainingPrincipal()))
+                .flatMap(o -> o.map(Stream::of).orElse(Stream.empty()));
+        final SellingThrottle t = new SellingThrottle();
+        final Stream<RecommendedInvestment> throttled = t.apply(recommendations, portfolioOverview);
+        assertThat(throttled)
+                .extracting(r -> r.descriptor().item())
+                .containsOnly(i3);
+    }
+
+    @Test
+    void picksAllBelowThreshold() {
+        final Rating rating = Rating.A;
+        final Investment i1 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.TEN)
+                .build();
+        final Investment i2 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.TEN.pow(2))
+                .build();
+        final Investment i3 = Investment.custom()
+                .setRating(rating)
+                .setRemainingPrincipal(BigDecimal.ONE)
+                .build();
+        final PortfolioOverview portfolioOverview = mockPortfolioOverview(10_000);
+        when(portfolioOverview.getCzkInvested(eq(rating))).thenReturn(BigDecimal.valueOf(2200));
+        final Stream<RecommendedInvestment> recommendations = Stream.of(i1, i2, i3)
+                .map(i -> new InvestmentDescriptor(i, () -> null))
+                .map(d -> d.recommend(d.item().getRemainingPrincipal()))
+                .flatMap(o -> o.map(Stream::of).orElse(Stream.empty()));
+        final SellingThrottle t = new SellingThrottle();
+        final Stream<RecommendedInvestment> throttled = t.apply(recommendations, portfolioOverview);
+        assertThat(throttled)
+                .extracting(r -> r.descriptor().item())
+                .containsOnly(i1, i3);
+    }
+
+    @Test
+    void noInput() {
+        final PortfolioOverview portfolioOverview = mockPortfolioOverview(10_000);
+        final Stream<RecommendedInvestment> recommendations = Stream.empty();
+        final SellingThrottle t = new SellingThrottle();
+        final Stream<RecommendedInvestment> throttled = t.apply(recommendations, portfolioOverview);
+        assertThat(throttled).isEmpty();
+    }
+}

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SellingJobTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SellingJobTest.java
@@ -32,7 +32,7 @@ class SellingJobTest extends AbstractRoboZonkyTest {
         assertThat(t.payload()).isNotNull()
                 .isInstanceOf(Selling.class);
         assertThat(t.prioritize()).isTrue();
-        assertThat(t.repeatEvery()).isEqualTo(Duration.ofDays(1));
+        assertThat(t.repeatEvery()).isEqualTo(Duration.ofHours(2));
     }
 
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SellingTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SellingTest.java
@@ -30,6 +30,7 @@ import com.github.robozonky.api.notifications.SellingStartedEvent;
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.remote.enums.InvestmentStatus;
+import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.api.strategies.SellStrategy;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
 import com.github.robozonky.app.tenant.PowerTenant;
@@ -49,6 +50,7 @@ class SellingTest extends AbstractZonkyLeveragingTest {
 
     private static Investment mockInvestment(final Loan loan) {
         return Investment.fresh(loan, 200)
+                .setRating(Rating.AAAAA)
                 .setOriginalTerm(1000)
                 .setRemainingPrincipal(BigDecimal.valueOf(100))
                 .setStatus(InvestmentStatus.ACTIVE)

--- a/robozonky-common/src/test/java/com/github/robozonky/common/async/ThreadPoolExecutorBasedSchedulerTest.java
+++ b/robozonky-common/src/test/java/com/github/robozonky/common/async/ThreadPoolExecutorBasedSchedulerTest.java
@@ -19,7 +19,9 @@ package com.github.robozonky.common.async;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.LongAccumulator;
 
 import com.github.robozonky.internal.util.AbstractMinimalRoboZonkyTest;
@@ -39,7 +41,8 @@ class ThreadPoolExecutorBasedSchedulerTest extends AbstractMinimalRoboZonkyTest 
             s1.shutdown();
             s2.shutdown();
         })) {
-            s.submit(r, Duration.ofMillis(1));
+            final ScheduledFuture<?> f = s.submit(r, Duration.ofMillis(1));
+            assertThat((Future)f).isNotNull();
             Thread.sleep(50); // give A LOT OF TIME for the repeat to actually happen
         }
         assertThat(accumulator.longValue()).isGreaterThanOrEqualTo(2);

--- a/robozonky-test/src/main/java/com/github/robozonky/test/AbstractRoboZonkyTest.java
+++ b/robozonky-test/src/main/java/com/github/robozonky/test/AbstractRoboZonkyTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractRoboZonkyTest extends AbstractMinimalRoboZonkyTest
         when(zonky.getBlockedAmounts()).thenAnswer(i -> Stream.empty());
         when(zonky.getStatistics()).thenReturn(Statistics.empty());
         when(zonky.getDevelopments(anyInt())).thenAnswer(i -> Stream.empty());
+        when(zonky.getInvestments(any())).thenAnswer(i -> Stream.empty());
         return zonky;
     }
 


### PR DESCRIPTION
The goal of this is to only sell investments in small amounts, so that the entire portfolio is not destabilized. 

This is necessary, since Zonky only recalculates their portfolios every 2 hours and investments sold between the recalculations therefore cause `PortfolioOverview` to become out of sync with reality. Since the selling operation is fundamentally asynchronous (we offer to sell, then someone in the future may decide to buy), we can not "fix" portfolio on our side, as that would require us to constantly query for sold investments, making sure we have included all of them in `PortfolioOverview`. 

This will make sure we only sell so much at once as not to affect the portfolio too much.
`SellingJob` will ensure that the operation happens often enough that even large selloffs can be accomplished within days at worst.