### PR TITLE
Add support for selling participations without fees

### DIFF
--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingThrottle.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SellingThrottle.java
@@ -74,8 +74,8 @@ final class SellingThrottle
         }
     }
 
-    private static long getMaxSelloffValue(final PortfolioOverview portfolioOverview, final Rating rating) {
-        final BigDecimal invested = portfolioOverview.getCzkInvested(rating);
+    private static long getMaxSelloffValue(final PortfolioOverview portfolioOverview) {
+        final BigDecimal invested = portfolioOverview.getCzkInvested();
         final BigDecimal sellable = BigDecimalCalculator.times(invested, MAX_SELLOFF_SHARE_PER_RATING);
         return sellable.longValue();
     }
@@ -85,11 +85,12 @@ final class SellingThrottle
                                                final PortfolioOverview portfolioOverview) {
         final Map<Rating, Set<RecommendedInvestment>> eligible = investmentDescriptors
                 .collect(Collectors.groupingBy(t -> t.descriptor().item().getRating(), Collectors.toSet()));
+        final long maxSeloffValue = getMaxSelloffValue(portfolioOverview);
         return eligible.entrySet().stream()
                 .flatMap(e -> {
                     final Rating r = e.getKey();
                     LOGGER.debug("Processing {} investments.", r);
-                    return determineSelloffByRating(e.getValue(), getMaxSelloffValue(portfolioOverview, r));
+                    return determineSelloffByRating(e.getValue(), maxSeloffValue);
                 });
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SelingThrottleTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/SelingThrottleTest.java
@@ -61,7 +61,7 @@ class SelingThrottleTest extends AbstractZonkyLeveragingTest {
                 .setRemainingPrincipal(BigDecimal.ONE)
                 .build();
         final PortfolioOverview portfolioOverview = mockPortfolioOverview(10_000);
-        when(portfolioOverview.getCzkInvested(eq(rating))).thenReturn(BigDecimal.valueOf(2200));
+        when(portfolioOverview.getCzkInvested()).thenReturn(BigDecimal.valueOf(2200));
         final Stream<RecommendedInvestment> recommendations = Stream.of(i1, i2, i3)
                 .map(i -> new InvestmentDescriptor(i, () -> null))
                 .map(d -> d.recommend(d.item().getRemainingPrincipal()))

--- a/robozonky-app/src/test/java/com/github/robozonky/app/transactions/TransactionProcessingJobTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/transactions/TransactionProcessingJobTest.java
@@ -32,6 +32,7 @@ class TransactionProcessingJobTest extends AbstractRoboZonkyTest {
         assertThat(t.payload()).isNotNull()
                 .isInstanceOf(IncomeProcessor.class);
         assertThat(t.repeatEvery()).isEqualTo(Duration.ofHours(1));
+        assertThat(t.prioritize()).isTrue();
     }
 
 }

--- a/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
@@ -87,28 +87,27 @@ complexExpression returns [ParsedStrategy result]
         )
     )
 
-    { boolean emptySellFiltersIsOk = true; }
+    { DefaultValues v = $d.result; }
     (
         (
             DELIM 'Prodej participací'
             s=sellFilterExpression {
+                v.setSellingMode(SellingMode.SELL_FILTERS);
                 sellFilters = $s.result;
-                if (sellFilters.isEmpty()) emptySellFiltersIsOk = false;
+            }
+        ) | (
+            'Prodávat všechny participace bez poplatku, které odpovídají filtrům tržiště.' {
+                v.setSellingMode(SellingMode.FREE_AND_OUTSIDE_STRATEGY);
+                sellFilters = Collections.emptySet();
             }
         ) | (
             'Prodej participací zakázán.' {
                 sellFilters = Collections.emptySet();
             }
         )
-    )? {
-        if (!emptySellFiltersIsOk) {
-            LogManager.getLogger(this.getClass())
-                .warn("Sell filters are missing without excuse. This is deprecated and will eventually break.");
-        }
-    }
+    )
 
     {
-        final DefaultValues v = $d.result;
         $result = new ParsedStrategy(v, portfolioStructures, investmentSizes,
                                      new FilterSupplier(v, primaryFilters, secondaryFilters, sellFilters));
     }

--- a/robozonky-strategy-natural/src/main/antlr4/imports/CommonFilters.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/CommonFilters.g4
@@ -11,6 +11,15 @@ import Tokens;
     import com.github.robozonky.strategy.natural.conditions.*;
 }
 
+saleFeeCondition returns [MarketplaceFilterCondition result]:
+    'prodej '
+    (
+        ( IS { $result = SmpFeePresenceCondition.PRESENT; } )  |
+        ( 'není ' { $result = SmpFeePresenceCondition.NOT_PRESENT; } )
+    )
+    'zpoplatněn'
+;
+
 regionCondition returns [MarketplaceFilterCondition result]:
     { BorrowerRegionCondition c = new BorrowerRegionCondition(); }
     'kraj klienta ' IS (

--- a/robozonky-strategy-natural/src/main/antlr4/imports/MarketplaceFilters.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/MarketplaceFilters.g4
@@ -126,7 +126,7 @@ sellFilterExpression returns [Collection<MarketplaceFilter> result]:
     { $result = new ArrayList<>(0); }
     (
         (j=sellMarketplaceFilter { $result.add($j.result); })
-    )*
+    )+
 ;
 
 jointMarketplaceFilter returns [MarketplaceFilter result]:

--- a/robozonky-strategy-natural/src/main/antlr4/imports/MarketplaceFilters.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/MarketplaceFilters.g4
@@ -149,8 +149,8 @@ secondaryMarketplaceFilter returns [MarketplaceFilter result]:
 
 sellMarketplaceFilter returns [MarketplaceFilter result]:
     { $result = new MarketplaceFilter(); }
-    'Prodat participaci, kde: ' r=secondaryMarketplaceFilterConditions { $result.when($r.result); }
-    ('(Ale ne když: ' s=secondaryMarketplaceFilterConditions { $result.butNotWhen($s.result); } ')')?
+    'Prodat participaci, kde: ' r=sellFilterConditions { $result.when($r.result); }
+    ('(Ale ne když: ' s=sellFilterConditions { $result.butNotWhen($s.result); } ')')?
 ;
 
 jointMarketplaceFilterConditions returns [Collection<MarketplaceFilterCondition> result]:
@@ -171,6 +171,13 @@ secondaryMarketplaceFilterConditions returns [Collection<MarketplaceFilterCondit
     { Collection<MarketplaceFilterCondition> result = new LinkedHashSet<>(); }
     (c1=secondaryMarketplaceFilterCondition { result.add($c1.result); } '; ')*
     c2=secondaryMarketplaceFilterCondition { result.add($c2.result); } DOT
+    { $result = result; }
+;
+
+sellFilterConditions returns [Collection<MarketplaceFilterCondition> result]:
+    { Collection<MarketplaceFilterCondition> result = new LinkedHashSet<>(); }
+    (c1=sellMarketplaceFilterCondition { result.add($c1.result); } '; ')*
+    c2=sellMarketplaceFilterCondition { result.add($c2.result); } DOT
     { $result = result; }
 ;
 
@@ -215,4 +222,22 @@ secondaryMarketplaceFilterCondition returns [MarketplaceFilterCondition result]:
     | c13=remainingPrincipalCondition { $result = $c13.result; }
     | c14=annuityCondition { $result = $c14.result; }
     | c15=revenueRateCondition { $result = $c15.result; }
+;
+
+sellMarketplaceFilterCondition returns [MarketplaceFilterCondition result]:
+    c1=regionCondition { $result = $c1.result; }
+    | c3=incomeCondition { $result = $c3.result; }
+    | c4=purposeCondition { $result = $c4.result; }
+    | c5=storyCondition { $result = $c5.result; }
+    | c6=termCondition { $result = $c6.result; }
+    | c7=amountCondition { $result = $c7.result; }
+    | c8=interestCondition { $result = $c8.result; }
+    | c9=relativeTermCondition { $result = $c9.result; }
+    | c10=elapsedTermCondition { $result = $c10.result; }
+    | c11=elapsedRelativeTermCondition { $result = $c11.result; }
+    | c12=insuranceCondition { $result = $c12.result; }
+    | c13=remainingPrincipalCondition { $result = $c13.result; }
+    | c14=annuityCondition { $result = $c14.result; }
+    | c15=revenueRateCondition { $result = $c15.result; }
+    | c16=saleFeeCondition { $result = $c16.result; }
 ;

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/AbstractWrapper.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/AbstractWrapper.java
@@ -16,7 +16,9 @@
 
 package com.github.robozonky.strategy.natural;
 
+import java.math.BigDecimal;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.github.robozonky.api.strategies.Descriptor;
 
@@ -31,6 +33,11 @@ abstract class AbstractWrapper<T extends Descriptor<?, ?, ?>> implements Wrapper
     @Override
     public T getOriginal() {
         return original;
+    }
+
+    @Override
+    public Optional<BigDecimal> saleFee() {
+        return Optional.empty();
     }
 
     @SuppressWarnings("unchecked")

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
@@ -28,6 +28,7 @@ class DefaultValues {
 
     private final DefaultPortfolio portfolio;
     private ReservationMode reservationMode = null;
+    private SellingMode sellingMode = null;
     private long targetPortfolioSize = Long.MAX_VALUE;
     private long minimumBalance = 0;
     private InvestmentSize investmentSize = new InvestmentSize();
@@ -49,6 +50,14 @@ class DefaultValues {
 
     public void setReservationMode(final ReservationMode reservationMode) {
         this.reservationMode = reservationMode;
+    }
+
+    public Optional<SellingMode> getSellingMode() {
+        return Optional.ofNullable(sellingMode);
+    }
+
+    public void setSellingMode(final SellingMode sellingMode) {
+        this.sellingMode = sellingMode;
     }
 
     public long getMinimumBalance() {

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/InvestmentWrapper.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/InvestmentWrapper.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.strategy.natural;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 import com.github.robozonky.api.Ratio;
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
@@ -87,6 +88,11 @@ final class InvestmentWrapper extends AbstractLoanWrapper<InvestmentDescriptor> 
     @Override
     public BigDecimal getRemainingPrincipal() {
         return investment.getRemainingPrincipal();
+    }
+
+    @Override
+    public Optional<BigDecimal> saleFee() {
+        return investment.getSmpFee();
     }
 
     @Override

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategy.java
@@ -18,6 +18,7 @@ package com.github.robozonky.strategy.natural;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.stream.Stream;
 
 import com.github.robozonky.api.strategies.InvestmentDescriptor;
@@ -27,6 +28,8 @@ import com.github.robozonky.api.strategies.SellStrategy;
 
 class NaturalLanguageSellStrategy implements SellStrategy {
 
+    private static final Comparator<RecommendedInvestment> COMPARATOR =
+            Comparator.comparing(r -> r.descriptor().item().getSmpFee().orElse(BigDecimal.ZERO));
     private final ParsedStrategy strategy;
 
     public NaturalLanguageSellStrategy(final ParsedStrategy p) {
@@ -55,6 +58,7 @@ class NaturalLanguageSellStrategy implements SellStrategy {
                 })
                 .orElse(Stream.empty())
                 .map(InvestmentDescriptor::recommend) // must do full amount; Zonky enforces
-                .flatMap(r -> r.map(Stream::of).orElse(Stream.empty()));
+                .flatMap(r -> r.map(Stream::of).orElse(Stream.empty()))
+                .sorted(COMPARATOR);
     }
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategy.java
@@ -59,6 +59,6 @@ class NaturalLanguageSellStrategy implements SellStrategy {
                 .orElse(Stream.empty())
                 .map(InvestmentDescriptor::recommend) // must do full amount; Zonky enforces
                 .flatMap(r -> r.map(Stream::of).orElse(Stream.empty()))
-                .sorted(COMPARATOR);
+                .sorted(COMPARATOR); // investments without sale fee come first
     }
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageStrategyService.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguageStrategyService.java
@@ -90,7 +90,7 @@ public class NaturalLanguageStrategyService implements StrategyService {
 
     @Override
     public Optional<SellStrategy> toSell(final String strategy) {
-        return getStrategy(strategy, s -> s.isSellingEnabled() ? new NaturalLanguageSellStrategy(s) : null);
+        return getStrategy(strategy, s -> s.getSellingMode().map(m -> new NaturalLanguageSellStrategy(s)).orElse(null));
     }
 
     @Override

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
@@ -187,10 +187,6 @@ class ParsedStrategy {
                 .map(Wrapper::getOriginal);
     }
 
-    public boolean isSellingEnabled() {
-        return !filters.getSellFilters().isEmpty();
-    }
-
     public boolean isPurchasingEnabled() {
         return filters.isSecondaryMarketplaceEnabled();
     }
@@ -203,11 +199,23 @@ class ParsedStrategy {
         return defaults.getReservationMode();
     }
 
-    public Stream<InvestmentDescriptor> getApplicableInvestments(final Collection<InvestmentDescriptor> i) {
+    public Optional<SellingMode> getSellingMode() {
+        return defaults.getSellingMode();
+    }
+
+    public Stream<InvestmentDescriptor> getInvestmentsMatchingSellFilters(final Collection<InvestmentDescriptor> i) {
         return i.parallelStream()
                 .map(Wrapper::wrap)
                 .filter(w -> matchesFilter(w, filters.getSellFilters(),
                                            "{} to be sold as it matched sell filter {}."))
+                .map(Wrapper::getOriginal);
+    }
+
+    public Stream<InvestmentDescriptor> getInvestmentsMatchingPrimaryMarketplaceFilters(final Collection<InvestmentDescriptor> i) {
+        return i.parallelStream()
+                .map(Wrapper::wrap)
+                .filter(w -> matchesFilter(w, filters.getPrimaryMarketplaceFilters(),
+                                           "{} sellable as it matched primary marketplace filter {}."))
                 .map(Wrapper::getOriginal);
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/SellingMode.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/SellingMode.java
@@ -1,0 +1,8 @@
+package com.github.robozonky.strategy.natural;
+
+public enum SellingMode {
+
+    SELL_FILTERS,
+    FREE_AND_OUTSIDE_STRATEGY;
+
+}

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/Wrapper.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/Wrapper.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.strategy.natural;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 import com.github.robozonky.api.Ratio;
 import com.github.robozonky.api.remote.enums.MainIncomeType;
@@ -72,6 +73,8 @@ public interface Wrapper<T> {
     int getOriginalAnnuity();
 
     BigDecimal getRemainingPrincipal();
+
+    Optional<BigDecimal> saleFee();
 
     T getOriginal();
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractBooleanCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractBooleanCondition.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.strategy.natural.conditions;
+
+import java.util.function.Predicate;
+
+import com.github.robozonky.strategy.natural.Wrapper;
+
+class AbstractBooleanCondition extends MarketplaceFilterConditionImpl {
+
+    private final Predicate<Wrapper<?>> predicate;
+    protected final boolean expected;
+
+    protected AbstractBooleanCondition(final Predicate<Wrapper<?>> predicate, final boolean expected) {
+        this.predicate = predicate;
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean test(final Wrapper<?> loan) {
+        final boolean actual = predicate.test(loan);
+        return actual == expected;
+    }
+}

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/SmpFeePresenceCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/SmpFeePresenceCondition.java
@@ -1,0 +1,19 @@
+package com.github.robozonky.strategy.natural.conditions;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+public final class SmpFeePresenceCondition extends AbstractBooleanCondition {
+
+    public static final MarketplaceFilterCondition PRESENT = new SmpFeePresenceCondition(true);
+    public static final MarketplaceFilterCondition NOT_PRESENT = new SmpFeePresenceCondition(false);
+
+    private SmpFeePresenceCondition(final boolean expectPresent) {
+        super(w -> w.saleFee().orElse(BigDecimal.ZERO).signum() > 0, expectPresent);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of("Sale fee present: " + expected + ".");
+    }
+}

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategyTest.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.strategy.natural;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Stream;
@@ -48,8 +49,13 @@ class NaturalLanguageSellStrategyTest {
     }
 
     private final Investment mockInvestment() {
+        return mockInvestment(BigDecimal.TEN);
+    }
+
+    private final Investment mockInvestment(final BigDecimal fee) {
         return Investment.custom()
                 .setRemainingPrincipal(BigDecimal.TEN)
+                .setSmpFee(fee)
                 .build();
     }
 
@@ -80,5 +86,23 @@ class NaturalLanguageSellStrategyTest {
         final Stream<RecommendedInvestment> result =
                 s.recommend(Collections.singletonList(mockDescriptor()), portfolio);
         assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void feeBasedInvestmentsNotApplicableInSelloffStrategy() {
+        final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
+        v.setSellingMode(SellingMode.FREE_AND_OUTSIDE_STRATEGY);
+        final ParsedStrategy p = spy(new ParsedStrategy(v));
+        doAnswer(e -> {
+            final Collection<InvestmentDescriptor> i = e.getArgument(0);
+            return i.stream();
+        }).when(p).getInvestmentsMatchingPrimaryMarketplaceFilters(any());
+        final SellStrategy s = new NaturalLanguageSellStrategy(p);
+        final PortfolioOverview portfolio = mock(PortfolioOverview.class);
+        final Investment i1 = mockInvestment();
+        final Investment i2 = mockInvestment(BigDecimal.ZERO);
+        final Stream<RecommendedInvestment> result =
+                s.recommend(Arrays.asList(mockDescriptor(i1), mockDescriptor(i2)), portfolio);
+        assertThat(result).extracting(d -> d.descriptor().item()).containsOnly(i2);
     }
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageSellStrategyTest.java
@@ -55,8 +55,10 @@ class NaturalLanguageSellStrategyTest {
 
     @Test
     void noLoansApplicable() {
-        final ParsedStrategy p = spy(new ParsedStrategy(DefaultPortfolio.PROGRESSIVE));
-        doReturn(Stream.empty()).when(p).getApplicableInvestments(any());
+        final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
+        v.setSellingMode(SellingMode.SELL_FILTERS);
+        final ParsedStrategy p = spy(new ParsedStrategy(v));
+        doReturn(Stream.empty()).when(p).getInvestmentsMatchingSellFilters(any());
         final SellStrategy s = new NaturalLanguageSellStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);
         final Stream<RecommendedInvestment> result =
@@ -66,11 +68,13 @@ class NaturalLanguageSellStrategyTest {
 
     @Test
     void someLoansApplicable() {
-        final ParsedStrategy p = spy(new ParsedStrategy(DefaultPortfolio.PROGRESSIVE));
+        final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
+        v.setSellingMode(SellingMode.SELL_FILTERS);
+        final ParsedStrategy p = spy(new ParsedStrategy(v));
         doAnswer(e -> {
             final Collection<InvestmentDescriptor> i = e.getArgument(0);
             return i.stream();
-        }).when(p).getApplicableInvestments(any());
+        }).when(p).getInvestmentsMatchingSellFilters(any());
         final SellStrategy s = new NaturalLanguageSellStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);
         final Stream<RecommendedInvestment> result =

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
@@ -146,7 +146,6 @@ class ParsedStrategyTest {
         final PortfolioShare share = new PortfolioShare(Rating.D, Ratio.fromPercentage(50), Ratio.fromPercentage(100));
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.singleton(share),
                                                            Collections.emptyMap());
-        System.out.println(share);
         assertSoftly(softly -> {
             softly.assertThat(strategy.getMinimumShare(Rating.D)).isEqualTo(Ratio.fromPercentage(50));
             softly.assertThat(strategy.getMaximumShare(Rating.D)).isEqualTo(Ratio.ONE);

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
@@ -87,7 +87,7 @@ class ParsedStrategyTest {
         assertSoftly(softly -> {
             softly.assertThat(strategy.getApplicableLoans(Collections.singleton(ld))).isEmpty();
             softly.assertThat(strategy.getApplicableParticipations(Collections.singleton(pd))).isEmpty();
-            softly.assertThat(strategy.getApplicableInvestments(Collections.singleton(id))).containsOnly(id);
+            softly.assertThat(strategy.getInvestmentsMatchingSellFilters(Collections.singleton(id))).containsOnly(id);
         });
     }
 
@@ -119,7 +119,7 @@ class ParsedStrategyTest {
             softly.assertThat(strategy.getApplicableLoans(Arrays.asList(ldOver, ldUnder))).containsOnly(ldUnder);
             softly.assertThat(strategy.getApplicableParticipations(Arrays.asList(pdOver, pdUnder)))
                     .containsOnly(pdUnder);
-            softly.assertThat(strategy.getApplicableInvestments(Arrays.asList(idOver, idUnder))).isEmpty();
+            softly.assertThat(strategy.getInvestmentsMatchingSellFilters(Arrays.asList(idOver, idUnder))).isEmpty();
         });
     }
 

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/WrapperTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/WrapperTest.java
@@ -46,7 +46,9 @@ class WrapperTest {
                 .setAnnuity(BigDecimal.ONE)
                 .build();
         final int invested = 200;
-        final Investment investment = Investment.fresh(loan, invested).build();
+        final Investment investment = Investment.fresh(loan, invested)
+                .setSmpFee(BigDecimal.ONE)
+                .build();
         final Wrapper<InvestmentDescriptor> w = Wrapper.wrap(new InvestmentDescriptor(investment, () -> loan));
         assertSoftly(softly -> {
             softly.assertThat(w.getStory()).isEqualTo(loan.getStory());
@@ -58,6 +60,7 @@ class WrapperTest {
             softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
             softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(investment.getRemainingMonths());
             softly.assertThat(w.getRemainingPrincipal()).isEqualTo(BigDecimal.valueOf(invested));
+            softly.assertThat(w.saleFee()).contains(BigDecimal.ONE);
             softly.assertThat(w.toString()).isNotNull();
         });
     }
@@ -82,6 +85,7 @@ class WrapperTest {
             softly.assertThat(w.getOriginalAnnuity()).isEqualTo(reservation.getAnnuity().intValue());
             softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(reservation.getTermInMonths());
             softly.assertThatThrownBy(w::getRemainingPrincipal).isInstanceOf(UnsupportedOperationException.class);
+            softly.assertThat(w.saleFee()).isEmpty();
             softly.assertThat(w.toString()).isNotNull();
         });
     }
@@ -106,6 +110,7 @@ class WrapperTest {
             softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
             softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(loan.getTermInMonths());
             softly.assertThatThrownBy(w::getRemainingPrincipal).isInstanceOf(UnsupportedOperationException.class);
+            softly.assertThat(w.saleFee()).isEmpty();
             softly.assertThat(w.toString()).isNotNull();
         });
     }
@@ -134,6 +139,7 @@ class WrapperTest {
             softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
             softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(loan.getTermInMonths());
             softly.assertThat(w.getRemainingPrincipal()).isEqualTo(BigDecimal.valueOf(invested));
+            softly.assertThat(w.saleFee()).isEmpty();
             softly.assertThat(w.toString()).isNotNull();
         });
     }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/WrapperTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/WrapperTest.java
@@ -19,13 +19,20 @@ package com.github.robozonky.strategy.natural;
 import java.math.BigDecimal;
 
 import com.github.robozonky.api.Ratio;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
+import com.github.robozonky.api.remote.entities.sanitized.Reservation;
+import com.github.robozonky.api.remote.enums.Rating;
+import com.github.robozonky.api.remote.enums.Region;
 import com.github.robozonky.api.strategies.InvestmentDescriptor;
 import com.github.robozonky.api.strategies.LoanDescriptor;
+import com.github.robozonky.api.strategies.ParticipationDescriptor;
+import com.github.robozonky.api.strategies.ReservationDescriptor;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.*;
 
 class WrapperTest {
 
@@ -50,6 +57,82 @@ class WrapperTest {
             softly.assertThat(w.getRevenueRate()).isEqualTo(Ratio.ZERO);
             softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
             softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(investment.getRemainingMonths());
+            softly.assertThat(w.getRemainingPrincipal()).isEqualTo(BigDecimal.valueOf(invested));
+            softly.assertThat(w.toString()).isNotNull();
+        });
+    }
+
+    @Test
+    void fromReservation() {
+        final Reservation reservation = Reservation.custom()
+                .setAnnuity(BigDecimal.ONE)
+                .setRating(Rating.D)
+                .setRegion(Region.JIHOCESKY)
+                .setRevenueRate(Ratio.ZERO)
+                .setInterestRate(Ratio.ONE)
+                .build();
+        final Wrapper<ReservationDescriptor> w = Wrapper.wrap(new ReservationDescriptor(reservation, () -> null));
+        assertSoftly(softly -> {
+            softly.assertThat(w.getStory()).isEqualTo(reservation.getStory());
+            softly.assertThat(w.getRegion()).isEqualTo(reservation.getRegion());
+            softly.assertThat(w.getRating()).isEqualTo(reservation.getRating());
+            softly.assertThat(w.getOriginalAmount()).isEqualTo(reservation.getAmount());
+            softly.assertThat(w.getInterestRate()).isEqualTo(Ratio.ONE);
+            softly.assertThat(w.getRevenueRate()).isEqualTo(Ratio.ZERO);
+            softly.assertThat(w.getOriginalAnnuity()).isEqualTo(reservation.getAnnuity().intValue());
+            softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(reservation.getTermInMonths());
+            softly.assertThatThrownBy(w::getRemainingPrincipal).isInstanceOf(UnsupportedOperationException.class);
+            softly.assertThat(w.toString()).isNotNull();
+        });
+    }
+
+    @Test
+    void fromLoan() {
+        final Loan loan = Loan.custom()
+                .setId(1)
+                .setAmount(100_000)
+                .setRevenueRate(Ratio.ZERO)
+                .setInterestRate(Ratio.ONE)
+                .setAnnuity(BigDecimal.ONE)
+                .build();
+        final Wrapper<LoanDescriptor> w = Wrapper.wrap(new LoanDescriptor(loan));
+        assertSoftly(softly -> {
+            softly.assertThat(w.getStory()).isEqualTo(loan.getStory());
+            softly.assertThat(w.getRegion()).isEqualTo(loan.getRegion());
+            softly.assertThat(w.getRating()).isEqualTo(loan.getRating());
+            softly.assertThat(w.getOriginalAmount()).isEqualTo(loan.getAmount());
+            softly.assertThat(w.getInterestRate()).isEqualTo(Ratio.ONE);
+            softly.assertThat(w.getRevenueRate()).isEqualTo(Ratio.ZERO);
+            softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
+            softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(loan.getTermInMonths());
+            softly.assertThatThrownBy(w::getRemainingPrincipal).isInstanceOf(UnsupportedOperationException.class);
+            softly.assertThat(w.toString()).isNotNull();
+        });
+    }
+
+    @Test
+    void fromParticipation() {
+        final Loan loan = Loan.custom()
+                .setId(1)
+                .setAmount(100_000)
+                .setRevenueRate(Ratio.ZERO)
+                .setInterestRate(Ratio.ONE)
+                .setAnnuity(BigDecimal.ONE)
+                .build();
+        final int invested = 200;
+        final Participation p = mock(Participation.class);
+        when(p.getInterestRate()).thenReturn(Ratio.ONE);
+        when(p.getRemainingPrincipal()).thenReturn(BigDecimal.valueOf(invested));
+        final Wrapper<ParticipationDescriptor> w = Wrapper.wrap(new ParticipationDescriptor(p, () -> loan));
+        assertSoftly(softly -> {
+            softly.assertThat(w.getStory()).isEqualTo(loan.getStory());
+            softly.assertThat(w.getRegion()).isEqualTo(loan.getRegion());
+            softly.assertThat(w.getRating()).isEqualTo(loan.getRating());
+            softly.assertThat(w.getOriginalAmount()).isEqualTo(loan.getAmount());
+            softly.assertThat(w.getInterestRate()).isEqualTo(Ratio.ONE);
+            softly.assertThat(w.getRevenueRate()).isEqualTo(Ratio.ZERO);
+            softly.assertThat(w.getOriginalAnnuity()).isEqualTo(loan.getAnnuity().intValue());
+            softly.assertThat(w.getRemainingTermInMonths()).isEqualTo(loan.getTermInMonths());
             softly.assertThat(w.getRemainingPrincipal()).isEqualTo(BigDecimal.valueOf(invested));
             softly.assertThat(w.toString()).isNotNull();
         });

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/SmpFeePresenceConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/SmpFeePresenceConditionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.strategy.natural.conditions;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.github.robozonky.strategy.natural.Wrapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SmpFeePresenceConditionTest {
+
+    @Test
+    void present() {
+        final Wrapper<?> l = mock(Wrapper.class);
+        when(l.saleFee()).thenReturn(Optional.empty());
+        assertThat(SmpFeePresenceCondition.PRESENT.test(l)).isFalse();
+        when(l.saleFee()).thenReturn(Optional.of(BigDecimal.ZERO));
+        assertThat(SmpFeePresenceCondition.PRESENT.test(l)).isFalse();
+        when(l.saleFee()).thenReturn(Optional.of(BigDecimal.ONE));
+        assertThat(SmpFeePresenceCondition.PRESENT.test(l)).isTrue();
+    }
+
+    @Test
+    void notPresent() {
+        final Wrapper<?> l = mock(Wrapper.class);
+        when(l.saleFee()).thenReturn(Optional.empty());
+        assertThat(SmpFeePresenceCondition.NOT_PRESENT.test(l)).isTrue();
+        when(l.saleFee()).thenReturn(Optional.of(BigDecimal.ZERO));
+        assertThat(SmpFeePresenceCondition.NOT_PRESENT.test(l)).isTrue();
+        when(l.saleFee()).thenReturn(Optional.of(BigDecimal.ONE));
+        assertThat(SmpFeePresenceCondition.NOT_PRESENT.test(l)).isFalse();
+    }
+}

--- a/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/complex
+++ b/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/complex
@@ -82,4 +82,5 @@ Ignorovat vše, kde: délka přesahuje 36 měsíců.
 # Pravidla pro filtry jsou stejná, jako v předchozí sekci.
 - Prodej participací
 
-Prodat participaci, kde: délka přesahuje 36 měsíců.
+Prodat participaci, kde: délka přesahuje 36 měsíců; prodej není zpoplatněn.
+Prodat participaci, kde: úrok přesahuje 10 % p.a.; prodej je zpoplatněn.

--- a/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/missing-filters1
+++ b/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/missing-filters1
@@ -3,4 +3,4 @@ Robot má udržovat uživatelem definované portfolio.
 Robot má zcela ignorovat rezervační systém.
 - Filtrování tržiště
 Ignorovat vše, kde: délka přesahuje 36 měsíců.
-- Prodej participací
+Prodej participací zakázán.

--- a/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/newlines-ansi-unix
+++ b/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/newlines-ansi-unix
@@ -9,3 +9,4 @@ Investovat maximálnì 2 % výše úvìru.
 - Filtrování tržištì
 Ignorovat úvìr, kde: délka je 49 až 84 mìsícù.
 Ignorovat participaci, kde: délka je 49 až 84 mìsícù.
+Prodej participací zakázán.

--- a/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/newlines-ansi-windows
+++ b/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/newlines-ansi-windows
@@ -9,3 +9,4 @@ Investovat maximálnì 2 % výše úvìru.
 - Filtrování tržištì
 Ignorovat úvìr, kde: délka je 49 až 84 mìsícù.
 Ignorovat participaci, kde: délka je 49 až 84 mìsícù.
+Prodej participací zakázán.


### PR DESCRIPTION
This has always been possible. Only now, we provide means to explicitly control the behavior. 

User can decide to sell participations with or without fees. And they can also decide to sell every participation without fees which does not match the current strategy. This should greatly help with cleaning up old portfolios, where the initial strategy was different from the present one.