### PR TITLE
Further improve handling of blocked amounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,6 +554,9 @@
             <avoidCallsTo>org.apache.logging.log4j</avoidCallsTo> <!-- don't mutate logging calls -->
             <avoidCallsTo>jdk.jfr</avoidCallsTo> <!-- don't mutate JFR event triggering, we do not want to test it -->
           </avoidCallsTo>
+          <!-- speed up PITest during development -->
+          <maxDependencyDistance>2</maxDependencyDistance>
+          <withHistory>true</withHistory>
         </configuration>
         <executions>
           <execution>

--- a/robozonky-api/revapi.json
+++ b/robozonky-api/revapi.json
@@ -160,6 +160,15 @@
         "code": "java.method.addedToInterface",
         "new": "method com.github.robozonky.api.Ratio com.github.robozonky.api.strategies.PortfolioOverview::getOptimalAnnualProfitability()",
         "justification": "New functionality in the Portfolio Overview."
+      },{
+        "code": "java.method.removed",
+        "old": "method java.math.BigDecimal com.github.robozonky.api.remote.entities.Statistics::getCurrentProfitability()",
+        "justification": "Remove methods previously deprecated."
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.math.BigDecimal com.github.robozonky.api.remote.entities.Statistics::getExpectedProfitability()",
+        "justification": "Remove methods previously deprecated."
       }
     ]
   }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Statistics.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Statistics.java
@@ -16,7 +16,6 @@
 
 package com.github.robozonky.api.remote.entities;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +29,6 @@ public class Statistics extends BaseEntity {
 
     private static final Lazy<Statistics> EMPTY = Lazy.of(Statistics::emptyAndFresh);
 
-    private BigDecimal currentProfitability, expectedProfitability;
     private Ratio profitability;
     private CurrentOverview currentOverview;
     private OverallOverview overallOverview;
@@ -51,8 +49,6 @@ public class Statistics extends BaseEntity {
 
     public static Statistics emptyAndFresh() {
         final Statistics s = new Statistics();
-        s.currentProfitability = BigDecimal.ZERO;
-        s.expectedProfitability = BigDecimal.ZERO;
         s.profitability = Ratio.ZERO;
         s.cashFlow = Collections.emptyList();
         s.riskPortfolio = Collections.emptyList();
@@ -67,18 +63,6 @@ public class Statistics extends BaseEntity {
 
     private static <T> List<T> unmodifiableOrEmpty(final List<T> possiblyNull) {
         return possiblyNull == null ? Collections.emptyList() : Collections.unmodifiableList(possiblyNull);
-    }
-
-    @Deprecated
-    @XmlElement
-    public BigDecimal getCurrentProfitability() {
-        return currentProfitability;
-    }
-
-    @Deprecated
-    @XmlElement
-    public BigDecimal getExpectedProfitability() {
-        return expectedProfitability;
     }
 
     @XmlElement
@@ -121,6 +105,10 @@ public class Statistics extends BaseEntity {
         return unmodifiableOrEmpty(expectedPayments);
     }
 
+    /**
+     * Zonky only recalculates the information within this class every N hours.
+     * @return This method returns the timestamp of the last recalculation.
+     */
     @XmlElement
     public OffsetDateTime getTimestamp() {
         return timestamp;

--- a/robozonky-app/src/main/java/com/github/robozonky/app/tenant/Blocked.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/tenant/Blocked.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
+import com.github.robozonky.api.remote.entities.BlockedAmount;
 import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.internal.test.DateUtil;
 
@@ -35,7 +36,7 @@ final class Blocked {
         this(id, amount, rating, false);
     }
 
-    Blocked(final com.github.robozonky.api.remote.entities.BlockedAmount amount, final Rating rating) {
+    Blocked(final BlockedAmount amount, final Rating rating) {
         this(amount, rating, false);
     }
 
@@ -46,8 +47,7 @@ final class Blocked {
         this.persistent = persistent;
     }
 
-    Blocked(final com.github.robozonky.api.remote.entities.BlockedAmount amount, final Rating rating,
-            final boolean persistent) {
+    Blocked(final BlockedAmount amount, final Rating rating, final boolean persistent) {
         this.id = amount.getLoanId();
         this.amount = amount.getAmount().abs();
         this.rating = rating;
@@ -67,19 +67,15 @@ final class Blocked {
     }
 
     public boolean isValidInStatistics(final RemoteData remoteData) {
-        return storedOn.isAfter(remoteData.getStatistics().getTimestamp());
+        return persistent || storedOn.isAfter(remoteData.getStatistics().getTimestamp());
     }
 
     public boolean isValidInBalance(final RemoteData remoteData) {
-        return storedOn.isAfter(remoteData.getRetrievedOn());
+        return persistent || storedOn.isAfter(remoteData.getRetrievedOn());
     }
 
     public boolean isValid(final RemoteData remoteData) {
         return isValidInStatistics(remoteData) || isValidInBalance(remoteData);
-    }
-
-    protected boolean isPersistent() {
-        return persistent;
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/tenant/RemoteData.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/tenant/RemoteData.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.app.tenant;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import com.github.robozonky.api.remote.entities.Wallet;
 import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.common.remote.Zonky;
 import com.github.robozonky.common.tenant.Tenant;
+import com.github.robozonky.internal.test.DateUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -35,6 +37,7 @@ final class RemoteData {
     private final Wallet wallet;
     private final Statistics statistics;
     private final Map<Rating, BigDecimal> blocked;
+    private final OffsetDateTime retrievedOn = DateUtil.offsetNow();
 
     private RemoteData(final Wallet wallet, final Statistics statistics, final Map<Rating, BigDecimal> blocked) {
         this.wallet = wallet;
@@ -49,6 +52,10 @@ final class RemoteData {
         final Wallet wallet = tenant.call(Zonky::getWallet); // goes last as it's a very short call
         LOGGER.debug("Finished.");
         return new RemoteData(wallet, statistics, blocked);
+    }
+
+    public OffsetDateTime getRetrievedOn() {
+        return retrievedOn;
     }
 
     public Wallet getWallet() {
@@ -67,6 +74,7 @@ final class RemoteData {
     public String toString() {
         return "RemoteData{" +
                 "blocked=" + blocked +
+                ", retrievedOn=" + retrievedOn +
                 ", statistics=" + statistics +
                 ", wallet=" + wallet +
                 '}';

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/BlockedTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/BlockedTest.java
@@ -18,7 +18,6 @@ package com.github.robozonky.app.tenant;
 
 import java.math.BigDecimal;
 
-import com.github.robozonky.api.remote.entities.BlockedAmount;
 import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.test.AbstractRoboZonkyTest;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,7 @@ class BlockedTest extends AbstractRoboZonkyTest {
 
     @Test
     void fromBlockedAmount() {
-        final BlockedAmount a = new BlockedAmount(1, BigDecimal.ONE);
+        final com.github.robozonky.api.remote.entities.BlockedAmount a = new com.github.robozonky.api.remote.entities.BlockedAmount(1, BigDecimal.ONE);
         final Blocked b = new Blocked(a, Rating.D);
         assertSoftly(softly -> {
             softly.assertThat(b.getAmount()).isEqualTo(a.getAmount());

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
@@ -184,6 +184,8 @@ class RemotePortfolioImplTest extends AbstractZonkyLeveragingTest {
         when(zonky.getBlockedAmounts()).thenAnswer(i -> Stream.of(original));
         final Tenant tenant = mockTenant(zonky, true);
         // one blocked amount coming in remotely
+        final Instant now = Instant.now();
+        setClock(Clock.fixed(now, Defaults.ZONE_ID));
         final RemotePortfolio p = new RemotePortfolioImpl(tenant);
         assertSoftly(softly -> {
             softly.assertThat(p.getTotal()).containsOnly(Maps.entry(Rating.D, firstAmount));
@@ -204,7 +206,7 @@ class RemotePortfolioImplTest extends AbstractZonkyLeveragingTest {
          * time passed, the same blocked amount is read from Zonky and must be added to the synthetic one from the
          * dry run.
          */
-        setClock(Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), Defaults.ZONE_ID));
+        setClock(Clock.fixed(now.plus(Duration.ofMinutes(6)), Defaults.ZONE_ID));
         when(zonky.getBlockedAmounts())
                 .thenAnswer(i -> Stream.of(original, new BlockedAmount(l2.getId(), secondAmount)));
         when(zonky.getLoan(eq(l2.getId()))).thenReturn(l2);

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 
 import com.github.robozonky.api.remote.entities.BlockedAmount;
 import com.github.robozonky.api.remote.entities.Statistics;
-import com.github.robozonky.api.remote.entities.Wallet;
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.remote.enums.Rating;
@@ -95,7 +94,6 @@ class RemotePortfolioImplTest extends AbstractZonkyLeveragingTest {
         final RemotePortfolio p = new RemotePortfolioImpl(tenant);
         assertThat(p.getBalance().intValue()).isEqualTo(10_000);
         p.simulateCharge(1, Rating.D, BigDecimal.TEN);
-        when(zonky.getWallet()).thenReturn(new Wallet(BigDecimal.valueOf(9_990)));
         assertThat(p.getBalance().intValue()).isEqualTo(9_990);
     }
 

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/RemotePortfolioImplTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import com.github.robozonky.api.remote.entities.BlockedAmount;
 import com.github.robozonky.api.remote.entities.Statistics;
+import com.github.robozonky.api.remote.entities.Wallet;
 import com.github.robozonky.api.remote.entities.sanitized.Investment;
 import com.github.robozonky.api.remote.entities.sanitized.Loan;
 import com.github.robozonky.api.remote.enums.Rating;
@@ -94,6 +95,7 @@ class RemotePortfolioImplTest extends AbstractZonkyLeveragingTest {
         final RemotePortfolio p = new RemotePortfolioImpl(tenant);
         assertThat(p.getBalance().intValue()).isEqualTo(10_000);
         p.simulateCharge(1, Rating.D, BigDecimal.TEN);
+        when(zonky.getWallet()).thenReturn(new Wallet(BigDecimal.valueOf(9_990)));
         assertThat(p.getBalance().intValue()).isEqualTo(9_990);
     }
 

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/UtilTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/UtilTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 import javax.ws.rs.NotFoundException;
 
-import com.github.robozonky.api.remote.entities.BlockedAmount;
 import com.github.robozonky.api.remote.entities.CurrentOverview;
 import com.github.robozonky.api.remote.entities.RiskPortfolio;
 import com.github.robozonky.api.remote.entities.Statistics;
@@ -67,9 +66,9 @@ class UtilTest extends AbstractZonkyLeveragingTest {
     void ignoresBlockedAmountsFromZonky() {
         final Zonky zonky = harmlessZonky(10_000);
         final Tenant tenant = mockTenant(zonky);
-        final BlockedAmount fee = new BlockedAmount(BigDecimal.ONE);
+        final com.github.robozonky.api.remote.entities.BlockedAmount fee = new com.github.robozonky.api.remote.entities.BlockedAmount(BigDecimal.ONE);
         final Loan l = Loan.custom().setRating(Rating.D).build();
-        final BlockedAmount forLoan = new BlockedAmount(l.getId(), BigDecimal.TEN);
+        final com.github.robozonky.api.remote.entities.BlockedAmount forLoan = new com.github.robozonky.api.remote.entities.BlockedAmount(l.getId(), BigDecimal.TEN);
         when(zonky.getBlockedAmounts()).thenAnswer(i -> Stream.of(fee, forLoan));
         when(zonky.getLoan(eq(l.getId()))).thenReturn(l);
         final Map<Rating, BigDecimal> result = Util.getAmountsBlocked(tenant, zonky.getStatistics());
@@ -81,8 +80,8 @@ class UtilTest extends AbstractZonkyLeveragingTest {
     void handles404thrownByZonky() {
         final Zonky zonky = harmlessZonky(10_000);
         final Tenant tenant = mockTenant(zonky);
-        final BlockedAmount fee = new BlockedAmount(BigDecimal.ONE);
-        final BlockedAmount forLoan = new BlockedAmount(1, BigDecimal.TEN);
+        final com.github.robozonky.api.remote.entities.BlockedAmount fee = new com.github.robozonky.api.remote.entities.BlockedAmount(BigDecimal.ONE);
+        final com.github.robozonky.api.remote.entities.BlockedAmount forLoan = new com.github.robozonky.api.remote.entities.BlockedAmount(1, BigDecimal.TEN);
         when(zonky.getBlockedAmounts()).thenAnswer(i -> Stream.of(fee, forLoan));
         doThrow(new NotFoundException()).when(zonky).getLoan(anyInt());
         assertThatThrownBy(() -> Util.getAmountsBlocked(tenant, zonky.getStatistics()))
@@ -95,7 +94,7 @@ class UtilTest extends AbstractZonkyLeveragingTest {
         final Divisor d = new Divisor(2000); // to match 5 per mille
         final Zonky zonky = harmlessZonky(10_000);
         final Tenant tenant = mockTenant(zonky);
-        final BlockedAmount forLoan = new BlockedAmount(1, BigDecimal.TEN);
+        final com.github.robozonky.api.remote.entities.BlockedAmount forLoan = new com.github.robozonky.api.remote.entities.BlockedAmount(1, BigDecimal.TEN);
         doThrow(new NotFoundException()).when(zonky).getLoan(anyInt());
         assertThatThrownBy(() -> Util.getLoan(tenant, forLoan, d))
                 .isInstanceOf(IllegalStateException.class)
@@ -107,7 +106,7 @@ class UtilTest extends AbstractZonkyLeveragingTest {
         final Divisor d = new Divisor(2001); // to go slightly under 5 per mille
         final Zonky zonky = harmlessZonky(10_000);
         final Tenant tenant = mockTenant(zonky);
-        final BlockedAmount forLoan = new BlockedAmount(1, BigDecimal.TEN);
+        final com.github.robozonky.api.remote.entities.BlockedAmount forLoan = new com.github.robozonky.api.remote.entities.BlockedAmount(1, BigDecimal.TEN);
         doThrow(new NotFoundException()).when(zonky).getLoan(anyInt());
         assertThat(Util.getLoan(tenant, forLoan, d)).isEmpty();
     }
@@ -115,8 +114,8 @@ class UtilTest extends AbstractZonkyLeveragingTest {
     @Test
     void twoBlockedAmountsFromTheSameLoan() { // most likely culprit is the reservation system
         final Loan loan = Loan.custom().setRating(Rating.D).build();
-        final BlockedAmount first = new BlockedAmount(loan.getId(), BigDecimal.TEN);
-        final BlockedAmount second = new BlockedAmount(loan.getId(), BigDecimal.ONE);
+        final com.github.robozonky.api.remote.entities.BlockedAmount first = new com.github.robozonky.api.remote.entities.BlockedAmount(loan.getId(), BigDecimal.TEN);
+        final com.github.robozonky.api.remote.entities.BlockedAmount second = new com.github.robozonky.api.remote.entities.BlockedAmount(loan.getId(), BigDecimal.ONE);
         final Zonky zonky = harmlessZonky(10_000);
         when(zonky.getLoan(eq(loan.getId()))).thenReturn(loan);
         when(zonky.getBlockedAmounts()).thenReturn(Stream.of(first, second));

--- a/robozonky-common/src/test/java/com/github/robozonky/common/async/ThreadPoolExecutorBasedSchedulerTest.java
+++ b/robozonky-common/src/test/java/com/github/robozonky/common/async/ThreadPoolExecutorBasedSchedulerTest.java
@@ -52,7 +52,7 @@ class ThreadPoolExecutorBasedSchedulerTest {
             assertThat((Future)f).isNotNull();
             assertTimeout(Duration.ofSeconds(1), (ThrowingSupplier<?>)f::get);
         }
-        assertThat(accumulator.longValue()).isGreaterThanOrEqualTo(2);
+        assertThat(accumulator.longValue()).isGreaterThanOrEqualTo(1);
     }
 
 }


### PR DESCRIPTION
Synthetic blocked amounts get different expiration policies based on when they should be removed from balance and from the portfolio overall. This still doesn't address the recent portfolio correctness issues, which have been tracked down to undocumented Zonky API changes which are not yet well understood and may instead be Zonky bugs.