### PR TITLE
Implement persistent authentication

### DIFF
--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/ZonkyApiToken.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/ZonkyApiToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,18 @@
 
 package com.github.robozonky.api.remote.entities;
 
+import java.io.Reader;
+import java.io.StringWriter;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -41,6 +47,20 @@ import com.github.robozonky.internal.test.DateUtil;
 @XmlRootElement(name = "token")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ZonkyApiToken extends BaseEntity {
+
+    public static ZonkyApiToken unmarshal(final Reader token) throws JAXBException {
+        final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
+        final Unmarshaller u = ctx.createUnmarshaller();
+        return (ZonkyApiToken) u.unmarshal(token);
+    }
+
+    public static String marshal(final ZonkyApiToken token) throws JAXBException {
+        final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
+        final Marshaller m = ctx.createMarshaller();
+        final StringWriter w = new StringWriter();
+        m.marshal(token, w);
+        return w.toString();
+    }
 
     public static final String REFRESH_TOKEN_STRING = "refresh_token";
 

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/ZonkyApiToken.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/ZonkyApiToken.java
@@ -16,7 +16,7 @@
 
 package com.github.robozonky.api.remote.entities;
 
-import java.io.Reader;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -48,24 +48,8 @@ import com.github.robozonky.internal.test.DateUtil;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ZonkyApiToken extends BaseEntity {
 
-    public static ZonkyApiToken unmarshal(final Reader token) throws JAXBException {
-        final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
-        final Unmarshaller u = ctx.createUnmarshaller();
-        return (ZonkyApiToken) u.unmarshal(token);
-    }
-
-    public static String marshal(final ZonkyApiToken token) throws JAXBException {
-        final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
-        final Marshaller m = ctx.createMarshaller();
-        final StringWriter w = new StringWriter();
-        m.marshal(token, w);
-        return w.toString();
-    }
-
     public static final String REFRESH_TOKEN_STRING = "refresh_token";
-
     private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
-
     @XmlTransient
     private final long id = ID_GENERATOR.getAndIncrement();
     @XmlElement(name = "access_token")
@@ -93,7 +77,8 @@ public class ZonkyApiToken extends BaseEntity {
     }
 
     public ZonkyApiToken(final String accessToken, final String refreshToken, final int expiresIn) {
-        this(accessToken, refreshToken, expiresIn, DateUtil.offsetNow(), REFRESH_TOKEN_STRING, OAuthScope.SCOPE_APP_WEB);
+        this(accessToken, refreshToken, expiresIn, DateUtil.offsetNow(), REFRESH_TOKEN_STRING,
+             OAuthScope.SCOPE_APP_WEB);
     }
 
     public ZonkyApiToken(final String accessToken, final String refreshToken, final int expiresIn,
@@ -114,6 +99,28 @@ public class ZonkyApiToken extends BaseEntity {
         this.type = type;
         this.scope = scope.length == 0 ? OAuthScopes.of() : OAuthScopes.of(scope);
         this.obtainedOn = obtainedOn;
+    }
+
+    public static ZonkyApiToken unmarshal(final String token) {
+        try {
+            final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
+            final Unmarshaller u = ctx.createUnmarshaller();
+            return (ZonkyApiToken) u.unmarshal(new StringReader(token));
+        } catch (final JAXBException ex) {
+            throw new IllegalStateException("Failed unmarshalling Zonky API token.", ex);
+        }
+    }
+
+    public static String marshal(final ZonkyApiToken token) {
+        try {
+            final JAXBContext ctx = JAXBContext.newInstance(ZonkyApiToken.class);
+            final Marshaller m = ctx.createMarshaller();
+            final StringWriter w = new StringWriter();
+            m.marshal(token, w);
+            return w.toString();
+        } catch (final JAXBException ex) {
+            throw new IllegalStateException("Failed marshalling Zonky API token.", ex);
+        }
     }
 
     public long getId() {

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/enums/OAuthScopes.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/enums/OAuthScopes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -77,5 +78,22 @@ public class OAuthScopes {
     @Override
     public String toString() {
         return scopes.stream().map(OAuthScope::name).collect(Collectors.joining(SEPARATOR));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !Objects.equals(getClass(), o.getClass())) {
+            return false;
+        }
+        final OAuthScopes that = (OAuthScopes) o;
+        return scopes.equals(that.scopes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopes);
     }
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/FallbackSecretProvider.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/FallbackSecretProvider.java
@@ -17,6 +17,9 @@
 package com.github.robozonky.internal.secrets;
 
 import java.util.Arrays;
+import java.util.Optional;
+
+import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 
 /**
  * Plain-text in-memory ephemeral secret storage. Should only ever be used for testing purposes.
@@ -25,6 +28,7 @@ final class FallbackSecretProvider implements SecretProvider {
 
     private final String username;
     private final char[] password;
+    private ZonkyApiToken token;
 
     public FallbackSecretProvider(final String username, final char... password) {
         this.username = username;
@@ -39,6 +43,17 @@ final class FallbackSecretProvider implements SecretProvider {
     @Override
     public String getUsername() {
         return this.username;
+    }
+
+    @Override
+    public synchronized Optional<ZonkyApiToken> getToken() {
+        return Optional.ofNullable(token);
+    }
+
+    @Override
+    public synchronized boolean setToken(ZonkyApiToken apiToken) {
+        this.token = apiToken;
+        return true;
     }
 
     @Override

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
@@ -96,6 +96,10 @@ final class KeyStoreSecretProvider implements SecretProvider {
 
     @Override
     public boolean setToken(ZonkyApiToken apiToken) {
+        if (apiToken == null) {
+            this.ksh.delete(ALIAS_TOKEN);
+            return true;
+        }
         try {
             return this.set(ALIAS_TOKEN, ZonkyApiToken.marshal(apiToken).toCharArray());
         } catch (final Exception ex) {

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
@@ -16,6 +16,9 @@
 
 package com.github.robozonky.internal.secrets;
 
+import java.util.Optional;
+
+import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -25,8 +28,10 @@ import org.apache.logging.log4j.Logger;
 final class KeyStoreSecretProvider implements SecretProvider {
 
     private static final Logger LOGGER = LogManager.getLogger(KeyStoreSecretProvider.class);
+
     private static final String ALIAS_PASSWORD = "pwd";
     private static final String ALIAS_USERNAME = "usr";
+    private static final String ALIAS_TOKEN = "tkn";
     private final KeyStoreHandler ksh;
 
     public KeyStoreSecretProvider(final KeyStoreHandler ksh) {
@@ -73,6 +78,30 @@ final class KeyStoreSecretProvider implements SecretProvider {
     public String getUsername() {
         return new String(this.ksh.get(ALIAS_USERNAME)
                                   .orElseThrow(() -> new IllegalStateException("Username not present in KeyStore.")));
+    }
+
+    @Override
+    public Optional<ZonkyApiToken> getToken() {
+        try {
+            final ZonkyApiToken result = this.ksh.get(ALIAS_TOKEN)
+                    .map(String::new)
+                    .map(ZonkyApiToken::unmarshal)
+                    .orElse(null);
+            return Optional.ofNullable(result);
+        } catch (final Exception ex) {
+            LOGGER.warn("Failed reading Zonky API token from the keystore.", ex);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean setToken(ZonkyApiToken apiToken) {
+        try {
+            return this.set(ALIAS_TOKEN, ZonkyApiToken.marshal(apiToken).toCharArray());
+        } catch (final Exception ex) {
+            LOGGER.warn("Failed storing Zonky API token to the keystore.", ex);
+            return false;
+        }
     }
 
     public boolean setPassword(final char[] password) {

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/KeyStoreSecretProvider.java
@@ -98,6 +98,7 @@ final class KeyStoreSecretProvider implements SecretProvider {
     public boolean setToken(ZonkyApiToken apiToken) {
         if (apiToken == null) {
             this.ksh.delete(ALIAS_TOKEN);
+            this.ksh.save();
             return true;
         }
         try {

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/SecretProvider.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/secrets/SecretProvider.java
@@ -17,6 +17,9 @@
 package com.github.robozonky.internal.secrets;
 
 import java.security.KeyStore;
+import java.util.Optional;
+
+import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 
 /**
  * Implementations provide various ways of storing sensitive information, such as passwords or access tokens.
@@ -70,6 +73,17 @@ public interface SecretProvider {
      * @return The username.
      */
     String getUsername();
+
+    /**
+     * @return Present if previously stored with {@link #setToken(ZonkyApiToken)}.
+     */
+    Optional<ZonkyApiToken> getToken();
+
+    /**
+     * @param apiToken If null, subsequent {@link #getToken()} calls will return empty {@link Optional}.
+     * @return True if stored.
+     */
+    boolean setToken(ZonkyApiToken apiToken);
 
     /**
      * Whether or not this provider will store all data in such a way that it survives JVM restart.

--- a/robozonky-api/src/main/java/module-info.java
+++ b/robozonky-api/src/main/java/module-info.java
@@ -59,7 +59,9 @@ module com.github.robozonky.api {
      * Extensions are managed by app and cli modules. Notifications are added as there is a slightly hackish
      * implementation of config sharing that wouldn't otherwise be possible.
      */
-    exports com.github.robozonky.internal.extensions to com.github.robozonky.app, com.github.robozonky.cli,
+    exports com.github.robozonky.internal.extensions to
+            com.github.robozonky.app,
+            com.github.robozonky.cli,
             com.github.robozonky.notifications;
 
     uses JobService;
@@ -68,8 +70,14 @@ module com.github.robozonky.api {
 
     provides JobService with StateCleanerJobService;
 
-    opens com.github.robozonky.api.remote.enums to com.fasterxml.jackson.databind, org.apache.commons.lang3;
-    opens com.github.robozonky.api.remote.entities to com.fasterxml.jackson.databind, org.apache.commons.lang3;
-    opens com.github.robozonky.api.remote.entities.sanitized to org.apache.commons.lang3;
+    opens com.github.robozonky.api.remote.entities to
+            java.xml.bind,
+            com.fasterxml.jackson.databind,
+            org.apache.commons.lang3;
+    opens com.github.robozonky.api.remote.enums to
+            com.fasterxml.jackson.databind,
+            org.apache.commons.lang3;
+    opens com.github.robozonky.api.remote.entities.sanitized to
+            org.apache.commons.lang3;
 
 }

--- a/robozonky-api/src/test/java/com/github/robozonky/api/remote/enums/OAuthScopesTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/api/remote/enums/OAuthScopesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.robozonky.api.remote.enums;
 
 import java.util.UUID;
@@ -80,5 +96,14 @@ class OAuthScopesTest {
     void ofSome() {
         final OAuthScopes result = OAuthScopes.of(OAuthScope.SCOPE_APP_WEB, OAuthScope.SCOPE_APP_OAUTH);
         assertThat(result.getOAuthScopes()).containsExactly(OAuthScope.SCOPE_APP_OAUTH, OAuthScope.SCOPE_APP_WEB);
+    }
+
+    @Test
+    void equals() {
+        final OAuthScopes result = OAuthScopes.of(OAuthScope.SCOPE_APP_WEB, OAuthScope.SCOPE_APP_OAUTH);
+        assertThat(result).isNotEqualTo(null);
+        assertThat(result).isEqualTo(result);
+        final OAuthScopes result2 = OAuthScopes.of(OAuthScope.SCOPE_APP_WEB, OAuthScope.SCOPE_APP_OAUTH);
+        assertThat(result).isEqualTo(result2);
     }
 }

--- a/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/FallbackSecretProviderTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/FallbackSecretProviderTest.java
@@ -16,6 +16,9 @@
 
 package com.github.robozonky.internal.secrets;
 
+import java.util.UUID;
+
+import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -34,4 +37,17 @@ class FallbackSecretProviderTest {
         assertThat(p.getPassword()).isEqualTo(FallbackSecretProviderTest.PWD.toCharArray());
         assertThat(p.isPersistent()).isFalse();
     }
+
+    @Test
+    void setToken() {
+        final SecretProvider p = SecretProvider.inMemory(FallbackSecretProviderTest.USR,
+                                                         FallbackSecretProviderTest.PWD.toCharArray());
+        // make sure original values were set
+        assertThat(p.getToken()).isEmpty();
+        final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
+        assertThat(p.setToken(token)).isTrue();
+        assertThat(p.getToken()).contains(token);
+    }
+
 }
+

--- a/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/KeyStoreSecretProviderTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/KeyStoreSecretProviderTest.java
@@ -92,6 +92,8 @@ class KeyStoreSecretProviderTest {
         final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
         assertThat(p.setToken(token)).isTrue();
         assertThat(p.getToken()).contains(token);
+        assertThat(p.setToken(null)).isTrue();
+        assertThat(p.getToken()).isEmpty();
     }
 
     @Test

--- a/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/KeyStoreSecretProviderTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/internal/secrets/KeyStoreSecretProviderTest.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.util.Optional;
+import java.util.UUID;
 
+import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
@@ -42,7 +44,7 @@ class KeyStoreSecretProviderTest {
         try {
             final File f = File.createTempFile("robozonky-", ".keystore");
             f.delete();
-            return KeyStoreHandler.create(f, KeyStoreSecretProviderTest.PWD.toCharArray());
+            return KeyStoreHandler.create(f, PWD.toCharArray());
         } catch (final IOException | KeyStoreException e) {
             fail("Something went wrong.", e);
             return null;
@@ -50,29 +52,28 @@ class KeyStoreSecretProviderTest {
     }
 
     private static KeyStoreSecretProvider newProvider(final String username, final String password) {
-        final KeyStoreHandler ksh = KeyStoreSecretProviderTest.getKeyStoreHandler();
+        final KeyStoreHandler ksh = getKeyStoreHandler();
         return (KeyStoreSecretProvider) SecretProvider.keyStoreBased(ksh, username, password.toCharArray());
     }
 
     @Test
     void usernameNotSet() {
-        assertThatThrownBy(() -> KeyStoreSecretProviderTest.newMockProvider().getUsername())
+        assertThatThrownBy(() -> newMockProvider().getUsername())
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void passwordNotSet() {
-        assertThatThrownBy(() -> KeyStoreSecretProviderTest.newMockProvider().getPassword())
+        assertThatThrownBy(() -> newMockProvider().getPassword())
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void setUsernameAndPassword() {
-        final KeyStoreSecretProvider p =
-                KeyStoreSecretProviderTest.newProvider(KeyStoreSecretProviderTest.USR, KeyStoreSecretProviderTest.PWD);
+        final KeyStoreSecretProvider p = newProvider(USR, PWD);
         // make sure original values were set
-        assertThat(p.getUsername()).isEqualTo(KeyStoreSecretProviderTest.USR);
-        assertThat(p.getPassword()).isEqualTo(KeyStoreSecretProviderTest.PWD.toCharArray());
+        assertThat(p.getUsername()).isEqualTo(USR);
+        assertThat(p.getPassword()).isEqualTo(PWD.toCharArray());
         // make sure updating them works
         final String usr = "something";
         assertThat(p.setUsername(usr)).isTrue();
@@ -81,6 +82,16 @@ class KeyStoreSecretProviderTest {
         assertThat(p.setPassword(pwd.toCharArray())).isTrue();
         assertThat(p.getPassword()).isEqualTo(pwd.toCharArray());
         assertThat(p.isPersistent()).isTrue();
+    }
+
+    @Test
+    void setToken() {
+        final SecretProvider p = newProvider(USR, PWD);
+        // make sure original values were set
+        assertThat(p.getToken()).isEmpty();
+        final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
+        assertThat(p.setToken(token)).isTrue();
+        assertThat(p.getToken()).contains(token);
     }
 
     @Test

--- a/robozonky-app/src/main/java/module-info.java
+++ b/robozonky-app/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module com.github.robozonky.app {
     requires org.apache.commons.lang3;
     requires org.apache.logging.log4j;
     requires com.github.robozonky.api;
+    requires resteasy.core;
 
     provides JobService with com.github.robozonky.app.events.EventFiringJobService,
             com.github.robozonky.app.version.VersionDetectionJobService,

--- a/robozonky-app/src/test/java/com/github/robozonky/app/CommandLineTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/CommandLineTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import com.github.robozonky.api.SessionInfo;
+import com.github.robozonky.app.daemon.Daemon;
 import com.github.robozonky.app.runtime.Lifecycle;
 import com.github.robozonky.internal.extensions.ListenerServiceLoader;
 import com.github.robozonky.internal.secrets.KeyStoreHandler;
@@ -85,7 +86,7 @@ class CommandLineTest extends AbstractRoboZonkyTest {
                                  "-s", "somewhere");
         final Optional<Function<Lifecycle, InvestmentMode>> cfg = CommandLine.parse(main);
         assertThat(cfg).isPresent();
-        cfg.get().apply(null);
+        assertThat(cfg.get().apply(null)).isInstanceOf(Daemon.class);
         assertThat(ListenerServiceLoader.getNotificationConfiguration(new SessionInfo(username))).isNotEmpty();
     }
 

--- a/robozonky-app/src/test/java/com/github/robozonky/app/events/AbstractEventLeveragingTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/events/AbstractEventLeveragingTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractEventLeveragingTest extends AbstractRoboZonkyTest 
 
     @AfterEach
     public void unregisterAllShutdownHooks() { // so that PITest can shut down all child processes
-        Lifecycle.clearShutdownHooks();
+        Lifecycle.getShutdownHooks().forEach(h -> Runtime.getRuntime().removeShutdownHook(h));
         Thread.setDefaultUncaughtExceptionHandler(null);
     }
 

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/DivisorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/DivisorTest.java
@@ -25,12 +25,12 @@ class DivisorTest extends AbstractRoboZonkyTest {
 
     @Test
     void calculate() {
-        Divisor d = new Divisor(2);
+        Divisor d = new Divisor(1);
         assertThat(d.getSharePerMille()).isEqualTo(0);
         d.add(1);
-        assertThat(d.getSharePerMille()).isEqualTo(500);
+        assertThat(d.getSharePerMille()).isEqualTo(1000);
         d.add(10);
-        assertThat(d.getSharePerMille()).isEqualTo(5500);
+        assertThat(d.getSharePerMille()).isEqualTo(11000);
     }
 
     @Test

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/PowerTenantImplTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/PowerTenantImplTest.java
@@ -18,6 +18,7 @@ package com.github.robozonky.app.tenant;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.github.robozonky.api.notifications.RoboZonkyDaemonSuspendedEvent;
 import com.github.robozonky.api.notifications.SellingCompletedEvent;
@@ -48,11 +49,13 @@ import static org.mockito.Mockito.*;
 class PowerTenantImplTest extends AbstractZonkyLeveragingTest {
 
     private static final SecretProvider SECRETS = SecretProvider.inMemory(SESSION.getUsername());
+    private static final ZonkyApiToken TOKEN = new ZonkyApiToken(UUID.randomUUID().toString(),
+                                                                 UUID.randomUUID().toString(), 299);
 
     @Test
     void closesWithTokens() {
         final OAuth a = mock(OAuth.class);
-        when(a.login(any(), any(), any())).thenReturn(mock(ZonkyApiToken.class));
+        when(a.login(any(), any(), any())).thenReturn(TOKEN);
         final Zonky z = harmlessZonky();
         final ApiProvider api = mockApiProvider(a, z);
         try (final Tenant tenant = new TenantBuilder().withSecrets(SECRETS).withApi(api).build()) {
@@ -62,7 +65,6 @@ class PowerTenantImplTest extends AbstractZonkyLeveragingTest {
             fail(e);
         }
         verify(a).login(any(), any(), any());
-        verify(z).logout();
     }
 
     @Test
@@ -82,7 +84,7 @@ class PowerTenantImplTest extends AbstractZonkyLeveragingTest {
     @Test
     void getters() throws Exception {
         final OAuth a = mock(OAuth.class);
-        when(a.login(any(), any(), any())).thenReturn(mock(ZonkyApiToken.class));
+        when(a.login(any(), any(), any())).thenReturn(TOKEN);
         final Zonky z = harmlessZonky();
         final Loan l = Loan.custom().setId(1).build();
         final Investment i = Investment.fresh(l, 200).build();

--- a/robozonky-app/src/test/java/com/github/robozonky/app/tenant/TenantBuilderTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/tenant/TenantBuilderTest.java
@@ -16,6 +16,8 @@
 
 package com.github.robozonky.app.tenant;
 
+import java.util.UUID;
+
 import com.github.robozonky.api.SessionInfo;
 import com.github.robozonky.api.remote.entities.ZonkyApiToken;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
@@ -32,10 +34,13 @@ import static org.mockito.Mockito.*;
 
 class TenantBuilderTest extends AbstractZonkyLeveragingTest {
 
+    private static final ZonkyApiToken TOKEN = new ZonkyApiToken(UUID.randomUUID().toString(),
+                                                                 UUID.randomUUID().toString(), 299);
+
     @Test
     void apiProvided() {
         final OAuth o = mock(OAuth.class);
-        when(o.login(any(), any(), any())).thenReturn(mock(ZonkyApiToken.class));
+        when(o.login(any(), any(), any())).thenReturn(TOKEN);
         final Zonky z = harmlessZonky();
         final ApiProvider a = mockApiProvider(o, z);
         final SecretProvider s = SecretProvider.inMemory("user", "pwd".toCharArray());


### PR DESCRIPTION
As Zonky moves to 2FA, logging in to the API will become more difficult. To make RoboZonky users as little impacted as possible, we implement persistent authentication. We will refresh the OAuth2 token for as long as we have it, and the token will survive restarts of the daemon.