### PR TITLE
Fix notifications sometimes containing incorrect information

### DIFF
--- a/robozonky-api/revapi.json
+++ b/robozonky-api/revapi.json
@@ -272,7 +272,7 @@
       {
         "code": "java.method.numberOfParametersChanged",
         "old": "method void com.github.robozonky.api.remote.entities.Participation::<init>()",
-        "new": "method void com.github.robozonky.api.remote.entities.Participation::<init>(com.github.robozonky.api.remote.entities.Loan)",
+        "new": "method void com.github.robozonky.api.remote.entities.Participation::<init>(com.github.robozonky.api.remote.entities.Loan, com.github.robozonky.api.Money, int)",
         "justification": "Allow the participation to be pre-filled."
       }
     ]

--- a/robozonky-api/revapi.json
+++ b/robozonky-api/revapi.json
@@ -255,6 +255,25 @@
         "code": "java.method.addedToInterface",
         "new": "method java.util.Collection<com.github.robozonky.api.remote.entities.Reservation> com.github.robozonky.api.notifications.ReservationCheckCompletedEvent::getReservationsAccepted()",
         "justification": "Replaces the Investment."
+      },{
+        "code": "java.annotation.added",
+        "old": "field com.github.robozonky.api.remote.entities.Participation.deadline",
+        "new": "field com.github.robozonky.api.remote.entities.Participation.deadline",
+        "annotation": "@javax.xml.bind.annotation.XmlElement",
+        "justification": "Nothing actually changed."
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "field com.github.robozonky.api.remote.entities.Participation.nextPaymentDate",
+        "new": "field com.github.robozonky.api.remote.entities.Participation.nextPaymentDate",
+        "annotation": "@javax.xml.bind.annotation.XmlElement",
+        "justification": "Nothing actually changed."
+      },
+      {
+        "code": "java.method.numberOfParametersChanged",
+        "old": "method void com.github.robozonky.api.remote.entities.Participation::<init>()",
+        "new": "method void com.github.robozonky.api.remote.entities.Participation::<init>(com.github.robozonky.api.remote.entities.Loan)",
+        "justification": "Allow the participation to be pre-filled."
       }
     ]
   }

--- a/robozonky-api/revapi.json
+++ b/robozonky-api/revapi.json
@@ -210,6 +210,51 @@
         "old": "method <T extends com.github.robozonky.api.notifications.Event> java.util.stream.Stream<com.github.robozonky.api.notifications.EventListenerSupplier<T>> com.github.robozonky.api.notifications.ListenerService::findListeners(java.lang.Class<T>)",
         "new": "method <T extends com.github.robozonky.api.notifications.Event> java.util.stream.Stream<com.github.robozonky.api.notifications.EventListenerSupplier<T>> com.github.robozonky.api.notifications.ListenerService::findListeners(com.github.robozonky.api.SessionInfo, java.lang.Class<T>)",
         "justification": "Notifications are newly tenant-based."
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.util.Collection<com.github.robozonky.api.remote.entities.Investment> com.github.robozonky.api.notifications.ExecutionCompletedEvent::getInvestments()",
+        "justification": "We can not have the correct Investment at this point."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<com.github.robozonky.api.remote.entities.Loan> com.github.robozonky.api.notifications.ExecutionCompletedEvent::getLoansInvestedInto()",
+        "justification": "Replaces the Investment."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method com.github.robozonky.api.Money com.github.robozonky.api.notifications.InvestmentMadeEvent::getInvestedAmount()",
+        "justification": "Replaces the Investment."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method com.github.robozonky.api.Money com.github.robozonky.api.notifications.InvestmentPurchasedEvent::getPurchasedAmount()",
+        "justification": "Replaces the Investment."
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.util.Collection<com.github.robozonky.api.remote.entities.Investment> com.github.robozonky.api.notifications.PurchasingCompletedEvent::getInvestments()",
+        "justification": "We can not have the correct Investment at this point."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<com.github.robozonky.api.remote.entities.Participation> com.github.robozonky.api.notifications.PurchasingCompletedEvent::getParticipationsPurchased()",
+        "justification": "Replaces the Investment."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method com.github.robozonky.api.Money com.github.robozonky.api.notifications.ReservationAcceptedEvent::getInvestedAmount()",
+        "justification": "Replaces the Investment."
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.util.Collection<com.github.robozonky.api.remote.entities.Investment> com.github.robozonky.api.notifications.ReservationCheckCompletedEvent::getInvestments()",
+        "justification": "We can not have the correct Investment at this point."
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<com.github.robozonky.api.remote.entities.Reservation> com.github.robozonky.api.notifications.ReservationCheckCompletedEvent::getReservationsAccepted()",
+        "justification": "Replaces the Investment."
       }
     ]
   }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ExecutionCompletedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ExecutionCompletedEvent.java
@@ -16,7 +16,7 @@
 
 package com.github.robozonky.api.notifications;
 
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Loan;
 
 import java.util.Collection;
 
@@ -25,6 +25,6 @@ import java.util.Collection;
  */
 public interface ExecutionCompletedEvent extends Financial {
 
-    Collection<Investment> getInvestments();
+    Collection<Loan> getLoansInvestedInto();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentMadeEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentMadeEvent.java
@@ -16,10 +16,14 @@
 
 package com.github.robozonky.api.notifications;
 
+import com.github.robozonky.api.Money;
+
 /**
  * Fired immediately after an investment was submitted to the API.
  */
-public interface InvestmentMadeEvent extends InvestmentBased,
+public interface InvestmentMadeEvent extends LoanBased,
                                              Financial {
+
+    Money getInvestedAmount();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentPurchasedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentPurchasedEvent.java
@@ -21,7 +21,7 @@ import com.github.robozonky.api.Money;
 /**
  * Fired immediately after secondary market purchase was submitted to the API.
  */
-public interface InvestmentPurchasedEvent extends LoanBased, Financial {
+public interface InvestmentPurchasedEvent extends ParticipationBased, Financial {
 
     Money getPurchasedAmount();
 

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentPurchasedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/InvestmentPurchasedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package com.github.robozonky.api.notifications;
 
+import com.github.robozonky.api.Money;
+
 /**
  * Fired immediately after secondary market purchase was submitted to the API.
  */
-public interface InvestmentPurchasedEvent extends InvestmentBased,
-                                                  Financial {
+public interface InvestmentPurchasedEvent extends LoanBased, Financial {
+
+    Money getPurchasedAmount();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/PurchaseRecommendedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/PurchaseRecommendedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.github.robozonky.api.strategies.PurchaseStrategy;
 
 /**
  * Fired immediately after {@link PurchaseStrategy} has recommended a particular loan.
- * {@link PurchaseRequestedEvent} may be fired next.
+ * {@link InvestmentPurchasedEvent} may be fired next.
  */
 public interface PurchaseRecommendedEvent extends ParticipationBased,
                                                   Recommending {

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/PurchasingCompletedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/PurchasingCompletedEvent.java
@@ -16,7 +16,7 @@
 
 package com.github.robozonky.api.notifications;
 
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Participation;
 
 import java.util.Collection;
 
@@ -28,6 +28,6 @@ public interface PurchasingCompletedEvent extends Financial {
     /**
      * @return The investments that were made.
      */
-    Collection<Investment> getInvestments();
+    Collection<Participation> getParticipationsPurchased();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ReservationAcceptedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ReservationAcceptedEvent.java
@@ -16,10 +16,14 @@
 
 package com.github.robozonky.api.notifications;
 
+import com.github.robozonky.api.Money;
+
 /**
  * Fired immediately after an investment was confirmed through the reservation system's API.
  */
-public interface ReservationAcceptedEvent extends InvestmentBased,
+public interface ReservationAcceptedEvent extends LoanBased,
                                                   Financial {
+
+    Money getInvestedAmount();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ReservationCheckCompletedEvent.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/notifications/ReservationCheckCompletedEvent.java
@@ -16,7 +16,7 @@
 
 package com.github.robozonky.api.notifications;
 
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Reservation;
 
 import java.util.Collection;
 
@@ -25,6 +25,6 @@ import java.util.Collection;
  */
 public interface ReservationCheckCompletedEvent extends Financial {
 
-    Collection<Investment> getInvestments();
+    Collection<Reservation> getReservationsAccepted();
 
 }

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Investment.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Investment.java
@@ -146,18 +146,6 @@ public class Investment extends BaseInvestment {
         this.additionallyInsured = loan.isAdditionallyInsured();
     }
 
-    public Investment(final Participation participation, final Money amount) {
-        super(participation, amount);
-        this.rating = participation.getRating();
-        this.interestRate = rating.getInterestRate();
-        this.revenueRate = rating.getMinimalRevenueRate(Instant.now());
-        this.remainingPrincipal = amount.getValue().toPlainString();
-        this.remainingMonths = participation.getRemainingInstalmentCount();
-        this.loanTermInMonth = participation.getOriginalInstalmentCount();
-        this.insuranceActive = participation.isInsuranceActive();
-        this.additionallyInsured = participation.isAdditionallyInsured();
-    }
-
     @XmlElement
     public Rating getRating() {
         return rating;

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Investment.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Investment.java
@@ -24,6 +24,7 @@ import io.vavr.Lazy;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,17 +137,25 @@ public class Investment extends BaseInvestment {
     public Investment(final Loan loan, final Money amount) {
         super(loan, amount);
         this.rating = loan.getRating();
+        this.interestRate = rating.getInterestRate();
+        this.revenueRate = rating.getMinimalRevenueRate(Instant.now());
         this.remainingPrincipal = amount.getValue().toPlainString();
         this.remainingMonths = loan.getTermInMonths();
         this.loanTermInMonth = loan.getTermInMonths();
+        this.insuranceActive = loan.isInsuranceActive();
+        this.additionallyInsured = loan.isAdditionallyInsured();
     }
 
     public Investment(final Participation participation, final Money amount) {
         super(participation, amount);
         this.rating = participation.getRating();
+        this.interestRate = rating.getInterestRate();
+        this.revenueRate = rating.getMinimalRevenueRate(Instant.now());
         this.remainingPrincipal = amount.getValue().toPlainString();
         this.remainingMonths = participation.getRemainingInstalmentCount();
         this.loanTermInMonth = participation.getOriginalInstalmentCount();
+        this.insuranceActive = participation.isInsuranceActive();
+        this.additionallyInsured = participation.isAdditionallyInsured();
     }
 
     @XmlElement

--- a/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Participation.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/api/remote/entities/Participation.java
@@ -30,43 +30,61 @@ import java.util.Currency;
 
 public class Participation extends BaseEntity {
 
-    private long borrowerNo;
-    private int loanId;
-    private int originalInstalmentCount;
-    private int remainingInstalmentCount;
-    private int userId;
-    private long id;
-    private long investmentId;
-    private MainIncomeType incomeType;
-    private Ratio interestRate;
-    private LoanHealthInfo loanHealthInfo;
-    private String loanName;
-    private Purpose purpose;
-    private Rating rating;
-    private boolean willExceedLoanInvestmentLimit;
-    private boolean insuranceActive;
-    private boolean additionallyInsured;
+    protected long borrowerNo;
+    protected int loanId;
+    protected int originalInstalmentCount;
+    protected int remainingInstalmentCount;
+    protected int userId;
+    protected long id;
+    protected long investmentId;
+    protected MainIncomeType incomeType;
+    protected Ratio interestRate;
+    protected LoanHealthInfo loanHealthInfo;
+    protected String loanName;
+    protected Purpose purpose;
+    protected Rating rating;
+    protected boolean willExceedLoanInvestmentLimit;
+    protected boolean insuranceActive;
+    protected boolean additionallyInsured;
     private Object loanInvestments;
 
     // dates and times are expensive to parse, and Participations are on the hot path. Only do it when needed.
     @XmlElement
-    private String deadline;
+    protected String deadline;
     private final Lazy<OffsetDateTime> deadlineParsed = Lazy.of(() -> OffsetDateTimeAdapter.fromString(deadline));
     @XmlElement
-    private String nextPaymentDate;
+    protected String nextPaymentDate;
     private final Lazy<LocalDate> nextPaymentDateParsed = Lazy.of(() -> LocalDateAdapter.fromString(nextPaymentDate));
 
-    private Country countryOfOrigin = Defaults.COUNTRY_OF_ORIGIN;
-    private Currency currency;
+    protected Country countryOfOrigin = Defaults.COUNTRY_OF_ORIGIN;
+    protected Currency currency;
     @XmlElement
-    private String remainingPrincipal;
+    protected String remainingPrincipal;
     private final Lazy<Money> moneyRemainingPrincipal = Lazy.of(() -> Money.from(remainingPrincipal, currency));
     @XmlElement
-    private String discount;
+    protected String discount;
     private final Lazy<Money> moneyDiscount = Lazy.of(() -> Money.from(discount, currency));
     @XmlElement
-    private String price;
+    protected String price;
     private final Lazy<Money> moneyPrice = Lazy.of(() -> Money.from(price, currency));
+
+    public Participation(final Loan loan, final Money remainingPrincipal, final int remainingInstalmentCount) {
+        this.loanId = loan.getId();
+        this.borrowerNo = loan.getBorrowerNo();
+        this.countryOfOrigin = loan.getCountryOfOrigin();
+        this.currency = loan.getCurrency();
+        this.incomeType = loan.getMainIncomeType();
+        this.interestRate = loan.getInterestRate();
+        this.loanName = loan.getName();
+        this.originalInstalmentCount = loan.getTermInMonths();
+        this.purpose = loan.getPurpose();
+        this.rating = loan.getRating();
+        this.userId = loan.getUserId();
+        this.additionallyInsured = loan.isAdditionallyInsured();
+        this.insuranceActive = loan.isInsuranceActive();
+        this.remainingPrincipal = remainingPrincipal.getValue().toPlainString();
+        this.remainingInstalmentCount = remainingInstalmentCount;
+    }
 
     @XmlElement
     public long getId() {

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/async/package-info.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/async/package-info.java
@@ -21,8 +21,6 @@
  * <ul>
  * <li>{@link com.github.robozonky.internal.async.Backoff} implements a mechanism to repeat a remote operation
  * over and over until it is eventually successful.</li>
- * <li>{@link com.github.robozonky.internal.async.Refreshable} provides a variable that automatically refreshes
- * itself from a remote operation on the background.</li>
  * <li>{@link com.github.robozonky.internal.async.Reloadable} provides a variable that refreshes itself from a remote
  * operation when accessed.</li>
  * </ul>

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/remote/entities/MutableParticipation.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/remote/entities/MutableParticipation.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 The RoboZonky Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.robozonky.internal.remote.entities;
+
+import com.github.robozonky.api.Money;
+import com.github.robozonky.api.Ratio;
+import com.github.robozonky.api.remote.entities.Loan;
+import com.github.robozonky.api.remote.entities.Participation;
+import com.github.robozonky.api.remote.enums.*;
+
+import java.util.Currency;
+
+public final class MutableParticipation extends Participation {
+
+    public MutableParticipation(Loan loan, final Money remainingPrincipal, final int remainingInstalmentCount) {
+        super(loan, remainingPrincipal, remainingInstalmentCount);
+    }
+
+    public void setBorrowerNo(final long borrowerNo) {
+        this.borrowerNo = borrowerNo;
+    }
+
+    public void setLoanId(final int loanId) {
+        this.loanId = loanId;
+    }
+
+    public void setOriginalInstalmentCount(final int originalInstalmentCount) {
+        this.originalInstalmentCount = originalInstalmentCount;
+    }
+
+    public void setRemainingInstalmentCount(final int remainingInstalmentCount) {
+        this.remainingInstalmentCount = remainingInstalmentCount;
+    }
+
+    public void setUserId(final int userId) {
+        this.userId = userId;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+    public void setInvestmentId(final long investmentId) {
+        this.investmentId = investmentId;
+    }
+
+    public void setIncomeType(final MainIncomeType incomeType) {
+        this.incomeType = incomeType;
+    }
+
+    public void setInterestRate(final Ratio interestRate) {
+        this.interestRate = interestRate;
+    }
+
+    public void setLoanHealthInfo(final LoanHealthInfo loanHealthInfo) {
+        this.loanHealthInfo = loanHealthInfo;
+    }
+
+    public void setLoanName(final String loanName) {
+        this.loanName = loanName;
+    }
+
+    public void setPurpose(final Purpose purpose) {
+        this.purpose = purpose;
+    }
+
+    public void setRating(final Rating rating) {
+        this.rating = rating;
+    }
+
+    public void setWillExceedLoanInvestmentLimit(final boolean willExceedLoanInvestmentLimit) {
+        this.willExceedLoanInvestmentLimit = willExceedLoanInvestmentLimit;
+    }
+
+    public void setInsuranceActive(final boolean insuranceActive) {
+        this.insuranceActive = insuranceActive;
+    }
+
+    public void setAdditionallyInsured(final boolean additionallyInsured) {
+        this.additionallyInsured = additionallyInsured;
+    }
+
+    public void setDeadline(final String deadline) {
+        this.deadline = deadline;
+    }
+
+    public void setNextPaymentDate(final String nextPaymentDate) {
+        this.nextPaymentDate = nextPaymentDate;
+    }
+
+    public void setCountryOfOrigin(final Country countryOfOrigin) {
+        this.countryOfOrigin = countryOfOrigin;
+    }
+
+    public void setCurrency(final Currency currency) {
+        this.currency = currency;
+    }
+
+    public void setRemainingPrincipal(final String remainingPrincipal) {
+        this.remainingPrincipal = remainingPrincipal;
+    }
+
+    public void setDiscount(final String discount) {
+        this.discount = discount;
+    }
+
+    public void setPrice(final String price) {
+        this.price = price;
+    }
+
+}

--- a/robozonky-api/src/main/java/module-info.java
+++ b/robozonky-api/src/main/java/module-info.java
@@ -68,7 +68,8 @@ module com.github.robozonky.api {
      * For the purposes of testing notification generation. We do not want any other code to create mutable entities.
      */
     exports com.github.robozonky.internal.remote.entities to
-            com.github.robozonky.notifications;
+            com.github.robozonky.notifications,
+            com.github.robozonky.app;
 
     uses JobService;
     uses com.github.robozonky.api.strategies.StrategyService;

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/AbstractSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/AbstractSession.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.remote.ControlApi;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.strategies.Descriptor;
 import com.github.robozonky.api.strategies.Recommended;
 import com.github.robozonky.app.tenant.PowerTenant;
@@ -32,7 +31,7 @@ abstract class AbstractSession<T extends Recommended<T, S, X>, S extends Descrip
 
     protected final PowerTenant tenant;
     protected final Logger logger;
-    protected final List<Investment> result = new ArrayList<>(0);
+    protected final List<X> result = new ArrayList<>(0);
     private final SessionState<S> discarded;
     private final Collection<S> stillAvailable;
 
@@ -75,7 +74,7 @@ abstract class AbstractSession<T extends Recommended<T, S, X>, S extends Descrip
      * Get investments made during this session.
      * @return Investments made so far during this session. Unmodifiable.
      */
-    List<Investment> getResult() {
+    List<X> getResult() {
         return Collections.unmodifiableList(result);
     }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingOperationDescriptor.java
@@ -18,6 +18,7 @@ package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.remote.entities.LastPublishedLoan;
+import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.InvestmentStrategy;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.app.tenant.PowerTenant;
@@ -27,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor, InvestmentStrategy> {
+class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor, InvestmentStrategy, Loan> {
 
     private final AtomicReference<LastPublishedLoan> lastChecked = new AtomicReference<>(null);
 
@@ -52,7 +53,7 @@ class InvestingOperationDescriptor implements OperationDescriptor<LoanDescriptor
     }
 
     @Override
-    public Operation<LoanDescriptor, InvestmentStrategy> getOperation() {
+    public Operation<LoanDescriptor, InvestmentStrategy, Loan> getOperation() {
         return InvestingSession::invest;
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/InvestingSession.java
@@ -83,7 +83,7 @@ final class InvestingSession extends AbstractSession<RecommendedLoan, LoanDescri
         tenant.getPortfolio().simulateCharge(i.getLoanId(), i.getRating(), amount);
         tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(amount));
         discard(recommendation.descriptor()); // never show again
-        tenant.fire(investmentMadeLazy(() -> investmentMade(i, l, tenant.getPortfolio().getOverview())));
+        tenant.fire(investmentMadeLazy(() -> investmentMade(l, amount, tenant.getPortfolio().getOverview())));
         logger.info("Invested {} into loan #{}.", amount, l.getId());
         return true;
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Operation.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Operation.java
@@ -16,14 +16,13 @@
 
 package com.github.robozonky.app.daemon;
 
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.app.tenant.PowerTenant;
 
 import java.util.Collection;
 
 @FunctionalInterface
-interface Operation<B, C> {
+interface Operation<B, C, D> {
 
-    Collection<Investment> apply(PowerTenant a, Collection<B> b, C c);
+    Collection<D> apply(PowerTenant a, Collection<B> b, C c);
 
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/OperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/OperationDescriptor.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Optional;
 
-interface OperationDescriptor<T, S> {
+interface OperationDescriptor<T, S, R> {
 
     boolean isEnabled(final Tenant tenant);
 
@@ -33,7 +33,7 @@ interface OperationDescriptor<T, S> {
 
     long identify(final T descriptor);
 
-    Operation<T, S> getOperation();
+    Operation<T, S, R> getOperation();
 
     Money getMinimumBalance(final PowerTenant tenant);
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingOperationDescriptor.java
@@ -17,6 +17,7 @@
 package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.ParticipationDescriptor;
 import com.github.robozonky.api.strategies.PurchaseStrategy;
 import com.github.robozonky.app.tenant.PowerTenant;
@@ -26,7 +27,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-class PurchasingOperationDescriptor implements OperationDescriptor<ParticipationDescriptor, PurchaseStrategy> {
+class PurchasingOperationDescriptor implements OperationDescriptor<ParticipationDescriptor, PurchaseStrategy, Participation> {
 
     private static final long[] NO_LONGS = new long[0];
     private final AtomicReference<long[]> lastChecked = new AtomicReference<>(NO_LONGS);
@@ -52,7 +53,7 @@ class PurchasingOperationDescriptor implements OperationDescriptor<Participation
     }
 
     @Override
-    public Operation<ParticipationDescriptor, PurchaseStrategy> getOperation() {
+    public Operation<ParticipationDescriptor, PurchaseStrategy, Participation> getOperation() {
         return PurchasingSession::purchase;
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
@@ -109,7 +109,7 @@ final class PurchasingSession extends
             result.add(participation);
             tenant.getPortfolio().simulateCharge(l.getId(), l.getRating(), recommendation.amount());
             tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(recommendation.amount()));
-            tenant.fire(investmentPurchasedLazy(() -> investmentPurchased(l, recommendation.amount(),
+            tenant.fire(investmentPurchasedLazy(() -> investmentPurchased(participation, l, recommendation.amount(),
                     tenant.getPortfolio().getOverview())));
         }
         return succeeded;

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
@@ -111,7 +111,8 @@ final class PurchasingSession extends
             result.add(i);
             tenant.getPortfolio().simulateCharge(i.getLoanId(), i.getRating(), i.getRemainingPrincipal().orElseThrow());
             tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(recommendation.amount()));
-            tenant.fire(investmentPurchasedLazy(() -> investmentPurchased(i, l, tenant.getPortfolio().getOverview())));
+            tenant.fire(investmentPurchasedLazy(() -> investmentPurchased(l, recommendation.amount(),
+                    tenant.getPortfolio().getOverview())));
         }
         return succeeded;
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PurchasingSession.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.ParticipationDescriptor;
@@ -46,9 +45,9 @@ final class PurchasingSession extends
                 Audit.purchasing());
     }
 
-    public static Collection<Investment> purchase(final PowerTenant auth,
-                                                  final Collection<ParticipationDescriptor> items,
-                                                  final PurchaseStrategy strategy) {
+    public static Collection<Participation> purchase(final PowerTenant auth,
+                                                     final Collection<ParticipationDescriptor> items,
+                                                     final PurchaseStrategy strategy) {
         final PurchasingSession s = new PurchasingSession(items, auth);
         final Collection<ParticipationDescriptor> c = s.getAvailable();
         if (c.isEmpty()) {
@@ -56,7 +55,7 @@ final class PurchasingSession extends
         }
         s.tenant.fire(purchasingStartedLazy(() -> purchasingStarted(c, auth.getPortfolio().getOverview())));
         s.purchase(strategy);
-        final Collection<Investment> result = s.getResult();
+        final Collection<Participation> result = s.getResult();
         s.tenant.fire(purchasingCompletedLazy(() -> purchasingCompleted(result, auth.getPortfolio().getOverview())));
         return Collections.unmodifiableCollection(result);
     }
@@ -105,11 +104,10 @@ final class PurchasingSession extends
         final Participation participation = recommendation.descriptor().item();
         final Loan l = recommendation.descriptor().related();
         final boolean succeeded = tenant.getSessionInfo().isDryRun() || actualPurchase(participation);
-        final Investment i = new Investment(participation, recommendation.amount());
         discard(recommendation.descriptor());
         if (succeeded) {
-            result.add(i);
-            tenant.getPortfolio().simulateCharge(i.getLoanId(), i.getRating(), i.getRemainingPrincipal().orElseThrow());
+            result.add(participation);
+            tenant.getPortfolio().simulateCharge(l.getId(), l.getRating(), recommendation.amount());
             tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(recommendation.amount()));
             tenant.fire(investmentPurchasedLazy(() -> investmentPurchased(l, recommendation.amount(),
                     tenant.getPortfolio().getOverview())));

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/ReservationSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/ReservationSession.java
@@ -100,7 +100,8 @@ final class ReservationSession extends AbstractSession<RecommendedReservation, R
         result.add(i);
         tenant.getPortfolio().simulateCharge(i.getLoanId(), i.getRating(), i.getAmount());
         tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(recommendation.amount()));
-        tenant.fire(reservationAcceptedLazy(() -> reservationAccepted(i, l, tenant.getPortfolio().getOverview())));
+        tenant.fire(reservationAcceptedLazy(() -> reservationAccepted(l, recommendation.amount(),
+                tenant.getPortfolio().getOverview())));
         return true;
     }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/ReservationSession.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/ReservationSession.java
@@ -16,7 +16,6 @@
 
 package com.github.robozonky.app.daemon;
 
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Reservation;
 import com.github.robozonky.api.strategies.PortfolioOverview;
@@ -44,9 +43,9 @@ final class ReservationSession extends AbstractSession<RecommendedReservation, R
               Audit.reservations());
     }
 
-    public static Collection<Investment> process(final PowerTenant tenant,
-                                                 final Collection<ReservationDescriptor> loans,
-                                                 final ReservationStrategy strategy) {
+    public static Collection<Reservation> process(final PowerTenant tenant,
+                                                  final Collection<ReservationDescriptor> loans,
+                                                  final ReservationStrategy strategy) {
         final ReservationSession s = new ReservationSession(loans, tenant);
         final PortfolioOverview portfolioOverview = tenant.getPortfolio().getOverview();
         s.tenant.fire(reservationCheckStarted(loans, portfolioOverview));
@@ -96,9 +95,8 @@ final class ReservationSession extends AbstractSession<RecommendedReservation, R
             return false;
         }
         final Loan l = recommendation.descriptor().related();
-        final Investment i = new Investment(l, recommendation.amount());
-        result.add(i);
-        tenant.getPortfolio().simulateCharge(i.getLoanId(), i.getRating(), i.getAmount());
+        result.add(recommendation.descriptor().item());
+        tenant.getPortfolio().simulateCharge(l.getId(), l.getRating(), recommendation.amount());
         tenant.setKnownBalanceUpperBound(tenant.getKnownBalanceUpperBound().subtract(recommendation.amount()));
         tenant.fire(reservationAcceptedLazy(() -> reservationAccepted(l, recommendation.amount(),
                 tenant.getPortfolio().getOverview())));

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
@@ -52,9 +52,10 @@ public final class EventFactory {
         return new InvestmentMadeEventImpl(loan, investedAmount, portfolioOverview);
     }
 
-    public static InvestmentPurchasedEvent investmentPurchased(final Loan loan, final Money purchasedAmount,
+    public static InvestmentPurchasedEvent investmentPurchased(final Participation participation, final Loan loan,
+                                                               final Money purchasedAmount,
                                                                final PortfolioOverview portfolioOverview) {
-        return new InvestmentPurchasedEventImpl(loan, purchasedAmount, portfolioOverview);
+        return new InvestmentPurchasedEventImpl(participation, loan, purchasedAmount, portfolioOverview);
     }
 
     public static InvestmentSoldEvent investmentSold(final Investment investment, final Loan loan,

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
@@ -16,6 +16,7 @@
 
 package com.github.robozonky.app.events.impl;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.*;
 import com.github.robozonky.api.remote.entities.Development;
 import com.github.robozonky.api.remote.entities.Investment;
@@ -48,14 +49,14 @@ public final class EventFactory {
         return new ExecutionStartedEventImpl(loans, portfolioOverview);
     }
 
-    public static InvestmentMadeEvent investmentMade(final Investment investment, final Loan loan,
+    public static InvestmentMadeEvent investmentMade(final Loan loan, final Money investedAmount,
                                                      final PortfolioOverview portfolioOverview) {
-        return new InvestmentMadeEventImpl(investment, loan, portfolioOverview);
+        return new InvestmentMadeEventImpl(loan, investedAmount, portfolioOverview);
     }
 
-    public static InvestmentPurchasedEvent investmentPurchased(final Investment investment, final Loan loan,
+    public static InvestmentPurchasedEvent investmentPurchased(final Loan loan, final Money purchasedAmount,
                                                                final PortfolioOverview portfolioOverview) {
-        return new InvestmentPurchasedEventImpl(investment, loan, portfolioOverview);
+        return new InvestmentPurchasedEventImpl(loan, purchasedAmount, portfolioOverview);
     }
 
     public static InvestmentSoldEvent investmentSold(final Investment investment, final Loan loan,
@@ -198,10 +199,9 @@ public final class EventFactory {
         return new ReservationAcceptationRecommendedEventImpl(recommendation);
     }
 
-    public static ReservationAcceptedEvent reservationAccepted(final Investment investment,
-                                                               final Loan loan,
+    public static ReservationAcceptedEvent reservationAccepted(final Loan loan, final Money investedAmount,
                                                                final PortfolioOverview portfolioOverview) {
-        return new ReservationAcceptedEventImpl(investment, loan, portfolioOverview);
+        return new ReservationAcceptedEventImpl(loan, investedAmount, portfolioOverview);
     }
 
     public static LazyEvent<ReservationAcceptedEvent> reservationAcceptedLazy(

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/EventFactory.java
@@ -18,9 +18,7 @@ package com.github.robozonky.app.events.impl;
 
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.*;
-import com.github.robozonky.api.remote.entities.Development;
-import com.github.robozonky.api.remote.entities.Investment;
-import com.github.robozonky.api.remote.entities.Loan;
+import com.github.robozonky.api.remote.entities.*;
 import com.github.robozonky.api.strategies.*;
 import com.github.robozonky.internal.tenant.LazyEvent;
 
@@ -39,7 +37,7 @@ public final class EventFactory {
         // no instances
     }
 
-    public static ExecutionCompletedEvent executionCompleted(final Collection<Investment> investments,
+    public static ExecutionCompletedEvent executionCompleted(final Collection<Loan> investments,
                                                              final PortfolioOverview portfolioOverview) {
         return new ExecutionCompletedEventImpl(investments, portfolioOverview);
     }
@@ -115,7 +113,7 @@ public final class EventFactory {
         return new PurchaseRecommendedEventImpl(recommendation);
     }
 
-    public static PurchasingCompletedEvent purchasingCompleted(final Collection<Investment> investment,
+    public static PurchasingCompletedEvent purchasingCompleted(final Collection<Participation> investment,
                                                                final PortfolioOverview portfolio) {
         return new PurchasingCompletedEventImpl(investment, portfolio);
     }
@@ -189,7 +187,7 @@ public final class EventFactory {
         return new ReservationCheckStartedEventImpl(reservations, portfolioOverview);
     }
 
-    public static ReservationCheckCompletedEvent reservationCheckCompleted(final Collection<Investment> investments,
+    public static ReservationCheckCompletedEvent reservationCheckCompleted(final Collection<Reservation> investments,
                                                                            final PortfolioOverview portfolioOverview) {
         return new ReservationCheckCompletedEventImpl(investments, portfolioOverview);
     }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ExecutionCompletedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ExecutionCompletedEventImpl.java
@@ -17,7 +17,7 @@
 package com.github.robozonky.app.events.impl;
 
 import com.github.robozonky.api.notifications.ExecutionCompletedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 import java.util.Collection;
@@ -25,10 +25,10 @@ import java.util.Collections;
 
 final class ExecutionCompletedEventImpl extends AbstractEventImpl implements ExecutionCompletedEvent {
 
-    private final Collection<Investment> investments;
+    private final Collection<Loan> investments;
     private final PortfolioOverview portfolioOverview;
 
-    public ExecutionCompletedEventImpl(final Collection<Investment> investment, final PortfolioOverview portfolio) {
+    public ExecutionCompletedEventImpl(final Collection<Loan> investment, final PortfolioOverview portfolio) {
         super("investments");
         this.investments = Collections.unmodifiableCollection(investment);
         this.portfolioOverview = portfolio;
@@ -40,7 +40,7 @@ final class ExecutionCompletedEventImpl extends AbstractEventImpl implements Exe
     }
 
     @Override
-    public Collection<Investment> getInvestments() {
+    public Collection<Loan> getLoansInvestedInto() {
         return investments;
     }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentMadeEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentMadeEventImpl.java
@@ -16,21 +16,20 @@
 
 package com.github.robozonky.app.events.impl;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentMadeEvent;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 final class InvestmentMadeEventImpl extends AbstractEventImpl implements InvestmentMadeEvent {
 
-    private final Investment investment;
     private final Loan loan;
+    private final Money investedAmount;
     private final PortfolioOverview portfolioOverview;
 
-    public InvestmentMadeEventImpl(final Investment investment, final Loan loan,
-                                   final PortfolioOverview portfolioOverview) {
-        this.investment = investment;
+    public InvestmentMadeEventImpl(final Loan loan, final Money amount, final PortfolioOverview portfolioOverview) {
         this.loan = loan;
+        this.investedAmount = amount;
         this.portfolioOverview = portfolioOverview;
     }
 
@@ -40,12 +39,13 @@ final class InvestmentMadeEventImpl extends AbstractEventImpl implements Investm
     }
 
     @Override
-    public Investment getInvestment() {
-        return this.investment;
+    public Money getInvestedAmount() {
+        return investedAmount;
     }
 
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
     }
+
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentPurchasedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentPurchasedEventImpl.java
@@ -19,16 +19,19 @@ package com.github.robozonky.app.events.impl;
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentPurchasedEvent;
 import com.github.robozonky.api.remote.entities.Loan;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 final class InvestmentPurchasedEventImpl extends AbstractEventImpl implements InvestmentPurchasedEvent {
 
+    private final Participation participation;
     private final Loan loan;
     private final Money purchasedAmount;
     private final PortfolioOverview portfolioOverview;
 
-    public InvestmentPurchasedEventImpl(final Loan loan, final Money amount,
+    public InvestmentPurchasedEventImpl(final Participation participation, final Loan loan, final Money amount,
                                         final PortfolioOverview portfolio) {
+        this.participation = participation;
         this.loan = loan;
         this.purchasedAmount = amount;
         this.portfolioOverview = portfolio;
@@ -43,9 +46,14 @@ final class InvestmentPurchasedEventImpl extends AbstractEventImpl implements In
     public Money getPurchasedAmount() {
         return purchasedAmount;
     }
+
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
     }
 
+    @Override
+    public Participation getParticipation() {
+        return participation;
+    }
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentPurchasedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/InvestmentPurchasedEventImpl.java
@@ -16,27 +16,22 @@
 
 package com.github.robozonky.app.events.impl;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentPurchasedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 final class InvestmentPurchasedEventImpl extends AbstractEventImpl implements InvestmentPurchasedEvent {
 
-    private final Investment investment;
     private final Loan loan;
+    private final Money purchasedAmount;
     private final PortfolioOverview portfolioOverview;
 
-    public InvestmentPurchasedEventImpl(final Investment investment, final Loan loan,
+    public InvestmentPurchasedEventImpl(final Loan loan, final Money amount,
                                         final PortfolioOverview portfolio) {
-        this.investment = investment;
         this.loan = loan;
+        this.purchasedAmount = amount;
         this.portfolioOverview = portfolio;
-    }
-
-    @Override
-    public Investment getInvestment() {
-        return this.investment;
     }
 
     @Override
@@ -45,7 +40,12 @@ final class InvestmentPurchasedEventImpl extends AbstractEventImpl implements In
     }
 
     @Override
+    public Money getPurchasedAmount() {
+        return purchasedAmount;
+    }
+    @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
     }
+
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/PurchasingCompletedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/PurchasingCompletedEventImpl.java
@@ -17,7 +17,7 @@
 package com.github.robozonky.app.events.impl;
 
 import com.github.robozonky.api.notifications.PurchasingCompletedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 import java.util.Collection;
@@ -25,17 +25,17 @@ import java.util.Collections;
 
 final class PurchasingCompletedEventImpl extends AbstractEventImpl implements PurchasingCompletedEvent {
 
-    private final Collection<Investment> investments;
+    private final Collection<Participation> investments;
     private final PortfolioOverview portfolioOverview;
 
-    public PurchasingCompletedEventImpl(final Collection<Investment> investment, final PortfolioOverview portfolio) {
+    public PurchasingCompletedEventImpl(final Collection<Participation> investment, final PortfolioOverview portfolio) {
         super("investments");
         this.investments = Collections.unmodifiableCollection(investment);
         this.portfolioOverview = portfolio;
     }
 
     @Override
-    public Collection<Investment> getInvestments() {
+    public Collection<Participation> getParticipationsPurchased() {
         return investments;
     }
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ReservationAcceptedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ReservationAcceptedEventImpl.java
@@ -16,21 +16,21 @@
 
 package com.github.robozonky.app.events.impl;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.ReservationAcceptedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 final class ReservationAcceptedEventImpl extends AbstractEventImpl implements ReservationAcceptedEvent {
 
-    private final Investment investment;
     private final Loan loan;
+    private final Money investedAmount;
     private final PortfolioOverview portfolioOverview;
 
-    public ReservationAcceptedEventImpl(final Investment investment, final Loan loan,
+    public ReservationAcceptedEventImpl(final Loan loan, final Money amount,
                                         final PortfolioOverview portfolioOverview) {
-        this.investment = investment;
         this.loan = loan;
+        this.investedAmount = amount;
         this.portfolioOverview = portfolioOverview;
     }
 
@@ -40,8 +40,8 @@ final class ReservationAcceptedEventImpl extends AbstractEventImpl implements Re
     }
 
     @Override
-    public Investment getInvestment() {
-        return this.investment;
+    public Money getInvestedAmount() {
+        return investedAmount;
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ReservationCheckCompletedEventImpl.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/events/impl/ReservationCheckCompletedEventImpl.java
@@ -17,7 +17,7 @@
 package com.github.robozonky.app.events.impl;
 
 import com.github.robozonky.api.notifications.ReservationCheckCompletedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Reservation;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 import java.util.Collection;
@@ -25,12 +25,13 @@ import java.util.Collections;
 
 final class ReservationCheckCompletedEventImpl extends AbstractEventImpl implements ReservationCheckCompletedEvent {
 
-    private final Collection<Investment> investments;
+    private final Collection<Reservation> investments;
     private final PortfolioOverview portfolioOverview;
 
-    public ReservationCheckCompletedEventImpl(final Collection<Investment> investment, final PortfolioOverview portfolio) {
+    public ReservationCheckCompletedEventImpl(final Collection<Reservation> reservations,
+                                              final PortfolioOverview portfolio) {
         super("investments");
-        this.investments = Collections.unmodifiableCollection(investment);
+        this.investments = Collections.unmodifiableCollection(reservations);
         this.portfolioOverview = portfolio;
     }
 
@@ -40,7 +41,7 @@ final class ReservationCheckCompletedEventImpl extends AbstractEventImpl impleme
     }
 
     @Override
-    public Collection<Investment> getInvestments() {
+    public Collection<Reservation> getReservationsAccepted() {
         return investments;
     }
 }

--- a/robozonky-app/src/main/java/module-info.java
+++ b/robozonky-app/src/main/java/module-info.java
@@ -19,7 +19,6 @@ import com.github.robozonky.internal.jobs.JobService;
 module com.github.robozonky.app {
     requires java.ws.rs;
     requires java.xml;
-    requires com.fasterxml.jackson.databind;
     requires info.picocli;
     requires io.vavr;
     requires org.apache.commons.lang3;

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingSessionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestingSessionTest.java
@@ -18,7 +18,7 @@ package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.*;
-import com.github.robozonky.api.remote.entities.Investment;
+import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.strategies.InvestmentStrategy;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.api.strategies.RecommendedLoan;
@@ -72,7 +72,7 @@ class InvestingSessionTest extends AbstractZonkyLeveragingTest {
         final int loanId = ld.item().getId();
         final PowerTenant auth = mockTenant(z);
         final Collection<LoanDescriptor> lds = Arrays.asList(ld, mockLoanDescriptor());
-        final Collection<Investment> i = InvestingSession.invest(auth, lds,
+        final Collection<Loan> i = InvestingSession.invest(auth, lds,
                                                                  mockStrategy(loanId, amount));
         // check that one investment was made
         assertThat(i).hasSize(1);
@@ -140,9 +140,8 @@ class InvestingSessionTest extends AbstractZonkyLeveragingTest {
             softly.assertThat(result).isTrue();
             softly.assertThat(t.getAvailable()).doesNotContain(r.descriptor());
         });
-        final List<Investment> investments = t.getResult();
+        final List<Loan> investments = t.getResult();
         assertThat(investments).hasSize(1);
-        assertThat(investments.get(0).getAmount()).isEqualTo(Money.from(amountToInvest));
         // validate event sequence
         final List<Event> newEvents = getEventsRequested();
         assertThat(newEvents)

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/InvestorTest.java
@@ -19,6 +19,7 @@ package com.github.robozonky.app.daemon;
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.SessionInfo;
 import com.github.robozonky.api.remote.entities.Loan;
+import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.api.strategies.LoanDescriptor;
 import com.github.robozonky.api.strategies.RecommendedLoan;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
@@ -46,6 +47,7 @@ import static org.mockito.Mockito.*;
 class InvestorTest extends AbstractZonkyLeveragingTest {
 
     private static final Loan LOAN = new MockLoanBuilder()
+            .setRating(Rating.A)
             .setNonReservedRemainingInvestment(100_000)
             .build();
     private static final LoanDescriptor DESCRIPTOR = new LoanDescriptor(LOAN);

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingSessionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/PurchasingSessionTest.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.enums.Rating;
@@ -50,7 +49,7 @@ class PurchasingSessionTest extends AbstractZonkyLeveragingTest {
     void empty() {
         final Zonky z = harmlessZonky();
         final PowerTenant auth = mockTenant(z);
-        final Collection<Investment> i = PurchasingSession.purchase(auth, Collections.emptyList(), null);
+        final Collection<Participation> i = PurchasingSession.purchase(auth, Collections.emptyList(), null);
         assertThat(i).isEmpty();
     }
 
@@ -78,7 +77,7 @@ class PurchasingSessionTest extends AbstractZonkyLeveragingTest {
         when(z.getLoan(eq(loanId))).thenReturn(l);
         final PowerTenant auth = mockTenant(z, false);
         final ParticipationDescriptor pd = new ParticipationDescriptor(p, () -> l);
-        final Collection<Investment> i = PurchasingSession.purchase(auth, Collections.singleton(pd), s);
+        final Collection<Participation> i = PurchasingSession.purchase(auth, Collections.singleton(pd), s);
         assertThat(i).hasSize(1);
         assertThat(getEventsRequested()).hasSize(4);
         verify(z).purchase(eq(p));
@@ -115,7 +114,7 @@ class PurchasingSessionTest extends AbstractZonkyLeveragingTest {
         when(z.purchase(any())).thenReturn(PurchaseResult.failure(thrown));
         final PowerTenant auth = mockTenant(z, false);
         final ParticipationDescriptor pd = new ParticipationDescriptor(p, () -> l);
-        final Collection<Investment> i = PurchasingSession.purchase(auth, Collections.singleton(pd), s);
+        final Collection<Participation> i = PurchasingSession.purchase(auth, Collections.singleton(pd), s);
         assertThat(i).isEmpty();
         assertThat(auth.getKnownBalanceUpperBound()).isEqualTo(Money.from(199));
     }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/ReservationSessionTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/ReservationSessionTest.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.MyReservation;
 import com.github.robozonky.api.remote.entities.Reservation;
@@ -53,7 +52,7 @@ class ReservationSessionTest extends AbstractZonkyLeveragingTest {
     void empty() {
         final Zonky z = harmlessZonky();
         final PowerTenant auth = mockTenant(z);
-        final Collection<Investment> i = ReservationSession.process(auth, Collections.emptyList(), null);
+        final Collection<Reservation> i = ReservationSession.process(auth, Collections.emptyList(), null);
         assertThat(i).isEmpty();
     }
 
@@ -79,7 +78,7 @@ class ReservationSessionTest extends AbstractZonkyLeveragingTest {
         when(z.getLoan(eq(l.getId()))).thenReturn(l);
         final PowerTenant auth = mockTenant(z, false);
         final ReservationDescriptor pd = new ReservationDescriptor(p, () -> l);
-        final Collection<Investment> i = ReservationSession.process(auth, Collections.singleton(pd), s);
+        final Collection<Reservation> i = ReservationSession.process(auth, Collections.singleton(pd), s);
         assertThat(i).hasSize(1);
         assertThat(getEventsRequested()).hasSize(4);
         verify(z).accept(eq(p));
@@ -110,7 +109,7 @@ class ReservationSessionTest extends AbstractZonkyLeveragingTest {
         when(z.getLoan(eq(loanId))).thenReturn(l);
         final PowerTenant auth = mockTenant(z);
         final ReservationDescriptor pd = new ReservationDescriptor(p, () -> l);
-        final Collection<Investment> i = ReservationSession.process(auth, Collections.singleton(pd), s);
+        final Collection<Reservation> i = ReservationSession.process(auth, Collections.singleton(pd), s);
         assertThat(i).hasSize(1);
         assertThat(getEventsRequested()).hasSize(4);
         verify(z, never()).accept(eq(p));
@@ -142,7 +141,7 @@ class ReservationSessionTest extends AbstractZonkyLeveragingTest {
         doThrow(IllegalStateException.class).when(z).accept(any());
         final PowerTenant auth = mockTenant(z, false);
         final ReservationDescriptor pd = new ReservationDescriptor(p, () -> l);
-        final Collection<Investment> i = ReservationSession.process(auth, Collections.singleton(pd), s);
+        final Collection<Reservation> i = ReservationSession.process(auth, Collections.singleton(pd), s);
         assertThat(i).isEmpty();
         assertThat(getEventsRequested()).hasSize(3);
         verify(z).accept(eq(p));

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/StrategyExecutorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/StrategyExecutorTest.java
@@ -18,7 +18,6 @@ package com.github.robozonky.app.daemon;
 
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.*;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.enums.Rating;
@@ -85,7 +84,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final ParticipationDescriptor pd = new ParticipationDescriptor(mock, () -> MockLoanBuilder.fresh());
         final PowerTenant tenant = mockTenant();
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor(pd);
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
         // check events
         final List<Event> events = getEventsRequested();
@@ -103,7 +102,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(zonky);
         when(tenant.getPurchaseStrategy()).thenReturn(Optional.of(NONE_ACCEPTING_PURCHASE_STRATEGY));
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor(pd);
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
         final List<Event> e = getEventsRequested();
         assertThat(e).hasSize(2);
@@ -135,7 +134,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(zonky);
         when(tenant.getPurchaseStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_PURCHASE_STRATEGY));
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor(pd);
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isNotEmpty();
         verify(zonky, never()).purchase(eq(mock)); // do not purchase as we're in dry run
         final List<Event> e = getEventsRequested();
@@ -173,7 +172,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(zonky, false);
         when(tenant.getPurchaseStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_PURCHASE_STRATEGY));
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor(pd);
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
     }
 
@@ -200,7 +199,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(zonky, false);
         when(tenant.getPurchaseStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_PURCHASE_STRATEGY));
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor(pd);
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         assertThatThrownBy(exec::get).isNotNull();
     }
 
@@ -209,7 +208,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final Zonky zonky = harmlessZonky();
         final PowerTenant tenant = mockTenant(zonky);
         final PurchasingOperationDescriptor d = mockPurchasingOperationDescriptor();
-        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<ParticipationDescriptor, PurchaseStrategy, Participation> exec = new StrategyExecutor<>(tenant, d);
         when(tenant.getPurchaseStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_PURCHASE_STRATEGY));
         assertThat(exec.get()).isEmpty();
         final List<Event> e = getEventsRequested();
@@ -225,7 +224,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final Zonky z = AbstractZonkyLeveragingTest.harmlessZonky();
         final PowerTenant tenant = mockTenant(z);
         final InvestingOperationDescriptor d = mockInvestingOperationDescriptor(ld);
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
         // check events
         final List<Event> events = getEventsRequested();
@@ -238,7 +237,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(z);
         when(tenant.getInvestmentStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_INVESTMENT_STRATEGY));
         final InvestingOperationDescriptor d = mockInvestingOperationDescriptor();
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
     }
 
@@ -257,7 +256,7 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         when(tenant.getInvestmentStrategy()).thenReturn(Optional.of(NONE_ACCEPTING_INVESTMENT_STRATEGY));
         when(z.getLoan(eq(loanId))).thenReturn(loan);
         final InvestingOperationDescriptor d = mockInvestingOperationDescriptor(ld);
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> exec = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> exec = new StrategyExecutor<>(tenant, d);
         assertThat(exec.get()).isEmpty();
     }
 
@@ -275,11 +274,11 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         final PowerTenant tenant = mockTenant(z);
         when(tenant.getInvestmentStrategy()).thenReturn(Optional.of(ALL_ACCEPTING_INVESTMENT_STRATEGY));
         final InvestingOperationDescriptor d = mockInvestingOperationDescriptor(ld);
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> exec = new StrategyExecutor<>(tenant, d);
-        final Collection<Investment> result = exec.get();
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> exec = new StrategyExecutor<>(tenant, d);
+        final Collection<Loan> result = exec.get();
         verify(z, never()).invest(any()); // dry run
         assertThat(result)
-                .extracting(Investment::getLoanId)
+                .extracting(Loan::getId)
                 .isEqualTo(Collections.singletonList(loanId));
         // re-check; no balance changed, no marketplace changed, nothing should happen
         assertThat(exec.get()).isEmpty();
@@ -291,10 +290,10 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
     void doesNotInvestWhenDisabled() {
         final Zonky zonky = harmlessZonky();
         final PowerTenant tenant = mockTenant(zonky);
-        final OperationDescriptor<LoanDescriptor, InvestmentStrategy> d = mock(OperationDescriptor.class);
+        final OperationDescriptor<LoanDescriptor, InvestmentStrategy, Loan> d = mock(OperationDescriptor.class);
         when(d.getLogger()).thenReturn(LogManager.getLogger());
         when(d.isEnabled(any())).thenReturn(false);
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> e = new StrategyExecutor<>(tenant, d);
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> e = new StrategyExecutor<>(tenant, d);
         assertThat(e.get()).isEmpty();
         verify(d, never()).newMarketplaceAccessor(any());
         final List<Event> evt = getEventsRequested();
@@ -314,8 +313,8 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         when(tenant.getAvailability().isAvailable()).thenReturn(true);
         when(tenant.getInvestmentStrategy())
                 .thenReturn(Optional.of((available, portfolio, restrictions) -> Stream.empty()));
-        final OperationDescriptor<LoanDescriptor, InvestmentStrategy> d = new InvestingOperationDescriptor();
-        final StrategyExecutor<LoanDescriptor, InvestmentStrategy> e = new StrategyExecutor<>(tenant, d);
+        final OperationDescriptor<LoanDescriptor, InvestmentStrategy, Loan> d = new InvestingOperationDescriptor();
+        final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> e = new StrategyExecutor<>(tenant, d);
         assertThat(e.get()).isEmpty();
         verify(zonky, times(1)).getLastPublishedLoanInfo();
         verify(zonky, times(1)).getAvailableLoans(any());

--- a/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
@@ -22,6 +22,7 @@ import com.github.robozonky.api.remote.entities.*;
 import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.api.strategies.*;
 import com.github.robozonky.app.AbstractZonkyLeveragingTest;
+import com.github.robozonky.internal.remote.entities.MutableParticipation;
 import com.github.robozonky.test.mock.MockInvestmentBuilder;
 import com.github.robozonky.test.mock.MockLoanBuilder;
 import com.github.robozonky.test.mock.MockReservationBuilder;
@@ -122,8 +123,11 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
 
     @Test
     void investmentPurchased() {
-        final InvestmentPurchasedEvent e = EventFactory.investmentPurchased(MockLoanBuilder.fresh(), Money.from(200),
-                                                                            mockPortfolioOverview());
+        final Loan loan = MockLoanBuilder.fresh();
+        final Participation participation = new MutableParticipation(loan, Money.from(200),
+                loan.getTermInMonths() - 1);
+        final InvestmentPurchasedEvent e = EventFactory.investmentPurchased(participation, loan, Money.from(200),
+                mockPortfolioOverview());
         assertSoftly(softly -> {
             softly.assertThat(e.getLoan()).isNotNull();
             softly.assertThat(e.getPurchasedAmount()).isEqualTo(Money.from(200));

--- a/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
@@ -111,23 +111,22 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
 
     @Test
     void investmentMade() {
-        final InvestmentMadeEvent e = EventFactory.investmentMade(MockInvestmentBuilder.fresh().build(),
-                MockLoanBuilder.fresh(), mockPortfolioOverview());
+        final InvestmentMadeEvent e = EventFactory.investmentMade(MockLoanBuilder.fresh(), Money.from(200),
+                mockPortfolioOverview());
         assertSoftly(softly -> {
             softly.assertThat(e.getLoan()).isNotNull();
-            softly.assertThat(e.getInvestment()).isNotNull();
+            softly.assertThat(e.getInvestedAmount()).isEqualTo(Money.from(200));
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
         });
     }
 
     @Test
     void investmentPurchased() {
-        final InvestmentPurchasedEvent e = EventFactory.investmentPurchased(MockInvestmentBuilder.fresh().build(),
-                                                                            MockLoanBuilder.fresh(),
+        final InvestmentPurchasedEvent e = EventFactory.investmentPurchased(MockLoanBuilder.fresh(), Money.from(200),
                                                                             mockPortfolioOverview());
         assertSoftly(softly -> {
             softly.assertThat(e.getLoan()).isNotNull();
-            softly.assertThat(e.getInvestment()).isNotNull();
+            softly.assertThat(e.getPurchasedAmount()).isEqualTo(Money.from(200));
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
         });
     }
@@ -236,11 +235,10 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
     @Test
     void reservationAccepted() {
         final Loan l = MockLoanBuilder.fresh();
-        final Investment i = MockInvestmentBuilder.fresh(l, 200).build();
-        final ReservationAcceptedEvent e = EventFactory.reservationAccepted(i, l, mockPortfolioOverview());
+        final ReservationAcceptedEvent e = EventFactory.reservationAccepted(l, Money.from(200), mockPortfolioOverview());
         assertSoftly(softly -> {
             softly.assertThat(e.getLoan()).isNotNull();
-            softly.assertThat(e.getInvestment()).isNotNull();
+            softly.assertThat(e.getInvestedAmount()).isEqualTo(Money.from(200));
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
         });
     }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/events/impl/EventFactoryTest.java
@@ -93,7 +93,7 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
         final ExecutionCompletedEvent e = EventFactory.executionCompleted(Collections.emptyList(),
                                                                           mockPortfolioOverview());
         assertSoftly(softly -> {
-            softly.assertThat(e.getInvestments()).isEmpty();
+            softly.assertThat(e.getLoansInvestedInto()).isEmpty();
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
             softly.assertThat(e.getCreatedOn()).isBeforeOrEqualTo(OffsetDateTime.now());
             softly.assertThat(e.toString()).isNotEmpty();
@@ -210,7 +210,7 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
         final PurchasingCompletedEvent e = EventFactory.purchasingCompleted(Collections.emptyList(),
                                                                             mockPortfolioOverview());
         assertSoftly(softly -> {
-            softly.assertThat(e.getInvestments()).isEmpty();
+            softly.assertThat(e.getParticipationsPurchased()).isEmpty();
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
         });
     }
@@ -248,7 +248,7 @@ class EventFactoryTest extends AbstractZonkyLeveragingTest {
         final ReservationCheckCompletedEvent e = EventFactory.reservationCheckCompleted(Collections.emptyList(),
                                                                                         mockPortfolioOverview());
         assertSoftly(softly -> {
-            softly.assertThat(e.getInvestments()).isEmpty();
+            softly.assertThat(e.getReservationsAccepted()).isEmpty();
             softly.assertThat(e.getPortfolioOverview()).isNotNull();
         });
     }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentMadeEventListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentMadeEventListener.java
@@ -20,6 +20,9 @@ import com.github.robozonky.api.notifications.InvestmentMadeEvent;
 import com.github.robozonky.notifications.AbstractTargetHandler;
 import com.github.robozonky.notifications.SupportedListener;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class InvestmentMadeEventListener extends AbstractListener<InvestmentMadeEvent> {
 
     public InvestmentMadeEventListener(final SupportedListener listener, final AbstractTargetHandler handler) {
@@ -30,6 +33,13 @@ public class InvestmentMadeEventListener extends AbstractListener<InvestmentMade
     public String getSubject(final InvestmentMadeEvent event) {
         return "Nová investice - " + event.getInvestedAmount().getValue().intValue() + ",- Kč, půjčka " +
                 Util.identifyLoan(event);
+    }
+
+    @Override
+    protected Map<String, Object> getData(InvestmentMadeEvent event) {
+        final Map<String, Object> result = new HashMap<>(super.getData(event));
+        result.put("amountHeld", event.getInvestedAmount().getValue());
+        return result;
     }
 
     @Override

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentMadeEventListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentMadeEventListener.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.notifications.listeners;
 
 import com.github.robozonky.api.notifications.InvestmentMadeEvent;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.notifications.AbstractTargetHandler;
 import com.github.robozonky.notifications.SupportedListener;
 
@@ -29,8 +28,8 @@ public class InvestmentMadeEventListener extends AbstractListener<InvestmentMade
 
     @Override
     public String getSubject(final InvestmentMadeEvent event) {
-        final Investment i = event.getInvestment();
-        return "Nová investice - " + i.getAmount().getValue().intValue() + ",- Kč, půjčka " + Util.identifyLoan(event);
+        return "Nová investice - " + event.getInvestedAmount().getValue().intValue() + ",- Kč, půjčka " +
+                Util.identifyLoan(event);
     }
 
     @Override

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentPurchasedEventListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/InvestmentPurchasedEventListener.java
@@ -20,6 +20,9 @@ import com.github.robozonky.api.notifications.InvestmentPurchasedEvent;
 import com.github.robozonky.notifications.AbstractTargetHandler;
 import com.github.robozonky.notifications.SupportedListener;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class InvestmentPurchasedEventListener extends AbstractListener<InvestmentPurchasedEvent> {
 
     public InvestmentPurchasedEventListener(final SupportedListener listener, final AbstractTargetHandler handler) {
@@ -29,6 +32,14 @@ public class InvestmentPurchasedEventListener extends AbstractListener<Investmen
     @Override
     public String getSubject(final InvestmentPurchasedEvent event) {
         return "Zakoupena participace k půjčce " + Util.identifyLoan(event);
+    }
+
+    @Override
+    protected Map<String, Object> getData(InvestmentPurchasedEvent event) {
+        final Map<String, Object> result = new HashMap<>(super.getData(event));
+        result.put("amountHeld", event.getPurchasedAmount().getValue());
+        result.put("loanTermRemaining", event.getParticipation().getRemainingInstalmentCount());
+        return result;
     }
 
     @Override

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/ReservationAcceptedEventListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/ReservationAcceptedEventListener.java
@@ -17,7 +17,6 @@
 package com.github.robozonky.notifications.listeners;
 
 import com.github.robozonky.api.notifications.ReservationAcceptedEvent;
-import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.notifications.AbstractTargetHandler;
 import com.github.robozonky.notifications.SupportedListener;
 
@@ -29,8 +28,8 @@ public class ReservationAcceptedEventListener extends AbstractListener<Reservati
 
     @Override
     public String getSubject(final ReservationAcceptedEvent event) {
-        final Investment i = event.getInvestment();
-        return "Rezervace potvrzena - " + i.getAmount().getValue().intValue() + ",- Kč, půjčka " + Util.identifyLoan(event);
+        return "Rezervace potvrzena - " + event.getInvestedAmount().getValue().intValue() + ",- Kč, půjčka " +
+                Util.identifyLoan(event);
     }
 
     @Override

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/ReservationAcceptedEventListener.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/listeners/ReservationAcceptedEventListener.java
@@ -20,6 +20,9 @@ import com.github.robozonky.api.notifications.ReservationAcceptedEvent;
 import com.github.robozonky.notifications.AbstractTargetHandler;
 import com.github.robozonky.notifications.SupportedListener;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ReservationAcceptedEventListener extends AbstractListener<ReservationAcceptedEvent> {
 
     public ReservationAcceptedEventListener(final SupportedListener listener, final AbstractTargetHandler handler) {
@@ -30,6 +33,13 @@ public class ReservationAcceptedEventListener extends AbstractListener<Reservati
     public String getSubject(final ReservationAcceptedEvent event) {
         return "Rezervace potvrzena - " + event.getInvestedAmount().getValue().intValue() + ",- Kč, půjčka " +
                 Util.identifyLoan(event);
+    }
+
+    @Override
+    protected Map<String, Object> getData(ReservationAcceptedEvent event) {
+        final Map<String, Object> result = new HashMap<>(super.getData(event));
+        result.put("amountHeld", event.getInvestedAmount().getValue());
+        return result;
     }
 
     @Override

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentMadeEvent.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentMadeEvent.java
@@ -16,15 +16,21 @@
 
 package com.github.robozonky.notifications.samples;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentMadeEvent;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
-public final class MyInvestmentMadeEvent extends AbstractInvestmentBasedEvent implements InvestmentMadeEvent {
+public final class MyInvestmentMadeEvent extends AbstractLoanBasedEvent implements InvestmentMadeEvent {
 
     private final PortfolioOverview portfolioOverview = Util.randomizePortfolioOverview();
 
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
+    }
+
+    @Override
+    public Money getInvestedAmount() {
+        return Money.from(200);
     }
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentPurchasedEvent.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentPurchasedEvent.java
@@ -18,20 +18,27 @@ package com.github.robozonky.notifications.samples;
 
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentPurchasedEvent;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
 public final class MyInvestmentPurchasedEvent extends AbstractLoanBasedEvent implements InvestmentPurchasedEvent {
 
+    private final Participation participation = Util.randomizeParticipation(getLoan());
     private final PortfolioOverview portfolioOverview = Util.randomizePortfolioOverview();
 
     @Override
     public Money getPurchasedAmount() {
-        return Money.from("123.45");
+        return getParticipation().getRemainingPrincipal();
     }
 
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
+    }
+
+    @Override
+    public Participation getParticipation() {
+        return participation;
     }
 
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentPurchasedEvent.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyInvestmentPurchasedEvent.java
@@ -16,15 +16,22 @@
 
 package com.github.robozonky.notifications.samples;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.InvestmentPurchasedEvent;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
-public final class MyInvestmentPurchasedEvent extends AbstractInvestmentBasedEvent implements InvestmentPurchasedEvent {
+public final class MyInvestmentPurchasedEvent extends AbstractLoanBasedEvent implements InvestmentPurchasedEvent {
 
     private final PortfolioOverview portfolioOverview = Util.randomizePortfolioOverview();
+
+    @Override
+    public Money getPurchasedAmount() {
+        return Money.from("123.45");
+    }
 
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
     }
+
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyReservationAcceptedEvent.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/MyReservationAcceptedEvent.java
@@ -16,15 +16,21 @@
 
 package com.github.robozonky.notifications.samples;
 
+import com.github.robozonky.api.Money;
 import com.github.robozonky.api.notifications.ReservationAcceptedEvent;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 
-public final class MyReservationAcceptedEvent extends AbstractInvestmentBasedEvent implements ReservationAcceptedEvent {
+public final class MyReservationAcceptedEvent extends AbstractLoanBasedEvent implements ReservationAcceptedEvent {
 
     private final PortfolioOverview portfolioOverview = Util.randomizePortfolioOverview();
 
     @Override
     public PortfolioOverview getPortfolioOverview() {
         return portfolioOverview;
+    }
+
+    @Override
+    public Money getInvestedAmount() {
+        return Money.from(200);
     }
 }

--- a/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/Util.java
+++ b/robozonky-notifications/src/main/java/com/github/robozonky/notifications/samples/Util.java
@@ -21,12 +21,14 @@ import com.github.robozonky.api.Ratio;
 import com.github.robozonky.api.remote.entities.Development;
 import com.github.robozonky.api.remote.entities.Investment;
 import com.github.robozonky.api.remote.entities.Loan;
+import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.enums.*;
 import com.github.robozonky.api.strategies.ExtendedPortfolioOverview;
 import com.github.robozonky.api.strategies.PortfolioOverview;
 import com.github.robozonky.internal.Defaults;
 import com.github.robozonky.internal.remote.entities.MutableDevelopment;
 import com.github.robozonky.internal.remote.entities.MutableLoan;
+import com.github.robozonky.internal.remote.entities.MutableParticipation;
 import com.github.robozonky.internal.test.DateUtil;
 
 import java.math.BigDecimal;
@@ -124,6 +126,11 @@ final class Util {
 
     public static Investment randomizeInvestment(final Loan loan) {
         return new Investment(loan, Money.from(200 + (RANDOM.nextInt(24) * 200L))); // from 200 to 5000
+    }
+
+    public static Participation randomizeParticipation(final Loan loan) {
+        return new MutableParticipation(loan, Money.from(200 + (RANDOM.nextInt(24) * 200L)),
+                RANDOM.nextInt(loan.getTermInMonths()));
     }
 
     public static PortfolioOverview randomizePortfolioOverview() {


### PR DESCRIPTION
This is due to the daemon returning Investment on success. These investments need to be fabricated as we don't actually query Zonky for them. And therefore they may occasionally contain wrong information which we incorrectly inferred from the Loan or the Participation.

We now remove these fabricated investments.