### PR TITLE
Make strategy execute fast filters first

### DIFF
--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParticipationWrapper.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParticipationWrapper.java
@@ -19,7 +19,6 @@ package com.github.robozonky.strategy.natural;
 import java.math.BigDecimal;
 
 import com.github.robozonky.api.Ratio;
-import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Participation;
 import com.github.robozonky.api.remote.enums.MainIncomeType;
 import com.github.robozonky.api.remote.enums.Purpose;
@@ -58,8 +57,7 @@ final class ParticipationWrapper extends AbstractLoanWrapper<ParticipationDescri
 
     @Override
     public Ratio getRevenueRate() {
-        final Loan loan = getLoan();
-        return loan.getRevenueRate().orElseGet(this::estimateRevenueRate);
+        return getLoan().getRevenueRate().orElseGet(this::estimateRevenueRate);
     }
 
     @Override

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractEnumeratedCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractEnumeratedCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,12 @@ class AbstractEnumeratedCondition<T> extends MarketplaceFilterConditionImpl impl
     private final Collection<T> possibleValues = new HashSet<>(0);
 
     protected AbstractEnumeratedCondition(final Function<Wrapper<?>, T> fieldRetriever) {
+        this(fieldRetriever, false);
+    }
+
+    protected AbstractEnumeratedCondition(final Function<Wrapper<?>, T> fieldRetriever,
+                                          final boolean mayRequireRemoteRequests) {
+        super(mayRequireRemoteRequests);
         this.fieldRetriever = fieldRetriever;
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractRangeCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractRangeCondition.java
@@ -32,6 +32,11 @@ abstract class AbstractRangeCondition<T extends Number & Comparable<T>> extends 
     private final RangeCondition<T> rangeCondition;
 
     protected AbstractRangeCondition(final RangeCondition<T> condition) {
+        this(condition, false);
+    }
+
+    protected AbstractRangeCondition(final RangeCondition<T> condition, final boolean mayRequireRemoteRequests) {
+        super(mayRequireRemoteRequests);
         this.rangeCondition = condition;
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractStoryCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/AbstractStoryCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.function.Predicate;
 
 import com.github.robozonky.strategy.natural.Wrapper;
 
-class AbstractStoryCondition extends MarketplaceFilterConditionImpl {
+abstract class AbstractStoryCondition extends MarketplaceFilterConditionImpl {
 
     // these values were the first and third quartile of story length in all loans between 2016-10-01 and 2017-05-20
     static final int SHORT_STORY_THRESHOLD = 200, LONG_STORY_THRESHOLD = 600;
@@ -29,6 +29,7 @@ class AbstractStoryCondition extends MarketplaceFilterConditionImpl {
     private final Predicate<String> storyLength;
 
     protected AbstractStoryCondition(final Predicate<String> storyLength) {
+        super(true);
         this.storyLength = storyLength;
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/BorrowerIncomeCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/BorrowerIncomeCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public class BorrowerIncomeCondition extends AbstractEnumeratedCondition<MainIncomeType> {
 
     public BorrowerIncomeCondition() {
-        super(Wrapper::getMainIncomeType);
+        super(Wrapper::getMainIncomeType, true);
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/BorrowerRegionCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/BorrowerRegionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public class BorrowerRegionCondition extends AbstractEnumeratedCondition<Region> {
 
     public BorrowerRegionCondition() {
-        super(Wrapper::getRegion);
+        super(Wrapper::getRegion, true);
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanAmountCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanAmountCondition.java
@@ -21,7 +21,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public final class LoanAmountCondition extends AbstractRangeCondition<Integer> {
 
     private LoanAmountCondition(final RangeCondition<Integer> condition) {
-        super(condition);
+        super(condition, true);
     }
 
     public static LoanAmountCondition lessThan(final int threshold) {
@@ -41,4 +41,5 @@ public final class LoanAmountCondition extends AbstractRangeCondition<Integer> {
                                                                minimumThreshold, maximumThreshold);
         return new LoanAmountCondition(c);
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanAnnuityCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanAnnuityCondition.java
@@ -21,7 +21,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public final class LoanAnnuityCondition extends AbstractRangeCondition<Integer> {
 
     private LoanAnnuityCondition(final RangeCondition<Integer> condition) {
-        super(condition);
+        super(condition, true);
     }
 
     public static LoanAnnuityCondition lessThan(final int threshold) {
@@ -41,4 +41,5 @@ public final class LoanAnnuityCondition extends AbstractRangeCondition<Integer> 
                                                                minimumThreshold, maximumThreshold);
         return new LoanAnnuityCondition(c);
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanPurposeCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/LoanPurposeCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public class LoanPurposeCondition extends AbstractEnumeratedCondition<Purpose> {
 
     public LoanPurposeCondition() {
-        super(Wrapper::getPurpose);
+        super(Wrapper::getPurpose, true);
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,14 @@ public interface MarketplaceFilterCondition extends Predicate<Wrapper<?>> {
 
     boolean test(final Wrapper<?> item);
 
+    /**
+     * @return True if, during the evaluation of this condition, a slow remote request could be triggered. This may
+     * happen in situations where the {@link Wrapper} requires information it does not (yet) have.
+     */
+    default boolean mayRequireRemoteRequests() {
+        return false;
+    }
+
     @Override
     default MarketplaceFilterCondition negate() {
         if (this instanceof NegatingCondition) {
@@ -52,4 +60,5 @@ public interface MarketplaceFilterCondition extends Predicate<Wrapper<?>> {
             return new NegatingCondition(this);
         }
     }
+
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterConditionImpl.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterConditionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,36 @@
 
 package com.github.robozonky.strategy.natural.conditions;
 
-abstract class MarketplaceFilterConditionImpl implements MarketplaceFilterCondition {
+/**
+ * Note: this class has a natural ordering that is inconsistent with equals.
+ */
+abstract class MarketplaceFilterConditionImpl implements MarketplaceFilterCondition,
+                                                         Comparable<MarketplaceFilterConditionImpl> {
+
+    private final boolean mayRequireRemoteRequests;
+
+    protected MarketplaceFilterConditionImpl(final boolean mayRequireRemoteRequests) {
+        this.mayRequireRemoteRequests = mayRequireRemoteRequests;
+    }
+
+    protected MarketplaceFilterConditionImpl() {
+        this(false);
+    }
+
+    @Override
+    public final boolean mayRequireRemoteRequests() {
+        return mayRequireRemoteRequests;
+    }
 
     @Override
     public String toString() {
         final String description = getDescription().orElse("N/A.");
         return this.getClass().getSimpleName() + " (" + description + ")";
+    }
+
+    @Override
+    public int compareTo(final MarketplaceFilterConditionImpl o) {
+        return Boolean.compare(mayRequireRemoteRequests(), o.mayRequireRemoteRequests());
     }
 
 }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/NegatingCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/NegatingCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ final class NegatingCondition extends MarketplaceFilterConditionImpl {
     private final MarketplaceFilterCondition toNegate;
 
     public NegatingCondition(final MarketplaceFilterCondition toNegate) {
+        super(toNegate.mayRequireRemoteRequests());
         this.toNegate = toNegate;
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/RevenueRateCondition.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/conditions/RevenueRateCondition.java
@@ -22,7 +22,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 public final class RevenueRateCondition extends AbstractRangeCondition<Ratio> {
 
     private RevenueRateCondition(final RangeCondition<Ratio> condition) {
-        super(condition);
+        super(condition, true);
     }
 
     public static RevenueRateCondition lessThan(final Ratio threshold) {
@@ -40,4 +40,5 @@ public final class RevenueRateCondition extends AbstractRangeCondition<Ratio> {
                                                              minimumThreshold, maximumThreshold);
         return new RevenueRateCondition(c);
     }
+
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageReservationStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageReservationStrategyTest.java
@@ -94,6 +94,7 @@ class NaturalLanguageReservationStrategyTest {
                 s.recommend(Collections.singletonList(new ReservationDescriptor(mockReservation(200), () -> null)),
                             portfolio, new Restrictions());
         assertThat(result).isEmpty();
+        assertThatThrownBy(s::getMode).isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/AlwaysAcceptingConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/AlwaysAcceptingConditionTest.java
@@ -26,6 +26,7 @@ class AlwaysAcceptingConditionTest {
     void negate() {
         final MarketplaceFilterCondition negated = AlwaysAcceptingCondition.INSTANCE.negate();
         assertThat(negated).isEqualTo(NeverAceptingCondition.INSTANCE);
+        assertThat(negated.mayRequireRemoteRequests()).isFalse();
     }
 
     @Test

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/AverageStoryConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/AverageStoryConditionTest.java
@@ -16,6 +16,8 @@
 
 package com.github.robozonky.strategy.natural.conditions;
 
+import java.util.function.Predicate;
+
 import com.github.robozonky.strategy.natural.Wrapper;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -56,4 +58,12 @@ class AverageStoryConditionTest {
         when(l.getStory()).thenReturn(story);
         assertThat(new AverageStoryCondition().test(l)).isFalse();
     }
+
+    @Test
+    void basicProperties() {
+        final AbstractStoryCondition condition = new AverageStoryCondition();
+        assertThat(condition.mayRequireRemoteRequests()).isTrue();
+        assertThat((Predicate<Wrapper<?>>) condition).hasToString(AverageStoryCondition.class.getSimpleName() + " (N/A.)");
+    }
+
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/LongStoryConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/LongStoryConditionTest.java
@@ -40,4 +40,11 @@ class LongStoryConditionTest {
         when(l.getStory()).thenReturn(story);
         assertThat(new LongStoryCondition().test(l)).isFalse();
     }
+
+    @Test
+    void expectsRemoteRequest() {
+        final AbstractStoryCondition condition = new LongStoryCondition();
+        assertThat(condition.mayRequireRemoteRequests()).isTrue();
+    }
+
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/MarketplaceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The RoboZonky Project
+ * Copyright 2019 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.github.robozonky.strategy.natural.conditions;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.function.Supplier;
 
 import com.github.robozonky.strategy.natural.Wrapper;
 import org.junit.jupiter.api.Test;
@@ -28,40 +27,46 @@ import static org.mockito.Mockito.*;
 
 class MarketplaceFilterTest {
 
-    private static final Supplier<MarketplaceFilterCondition> MATCHING = MarketplaceFilterCondition::alwaysAccepting;
-    private static final Supplier<MarketplaceFilterCondition> NOT_MATCHING = MarketplaceFilterCondition::neverAccepting;
+    private static final MarketplaceFilterCondition MATCHING = new MarketplaceFilterConditionImpl() {
+        @Override
+        public boolean test(Wrapper<?> item) {
+            return true;
+        }
+    };
+    private static final MarketplaceFilterCondition NOT_MATCHING = MATCHING.negate();
 
     @Test
     void noConditions() {
-        final MarketplaceFilterConditionImpl f = new MarketplaceFilter();
+        final MarketplaceFilterCondition f = new MarketplaceFilter();
         assertThat(f.test(mock(Wrapper.class))).isTrue();
+        assertThat(f.toString()).isNotEmpty();
     }
 
     @Test
     void oneMatching() {
         final MarketplaceFilter f = new MarketplaceFilter();
-        f.when(Collections.singletonList(MATCHING.get()));
+        f.when(Collections.singletonList(MATCHING));
         assertThat(f.test(mock(Wrapper.class))).isTrue();
     }
 
     @Test
     void notAllMatching() {
         final MarketplaceFilter f = new MarketplaceFilter();
-        f.when(Arrays.asList(MATCHING.get(), NOT_MATCHING.get(), MATCHING.get()));
+        f.when(Arrays.asList(MATCHING, NOT_MATCHING, MATCHING));
         assertThat(f.test(mock(Wrapper.class))).isFalse();
     }
 
     @Test
     void secondaryOneNotMatching() {
         final MarketplaceFilter f = new MarketplaceFilter();
-        f.butNotWhen(Collections.singleton(NOT_MATCHING.get()));
+        f.butNotWhen(Collections.singleton(NOT_MATCHING));
         assertThat(f.test(mock(Wrapper.class))).isTrue();
     }
 
     @Test
     void secondaryAllMatching() {
         final MarketplaceFilter f = new MarketplaceFilter();
-        f.butNotWhen(Arrays.asList(MATCHING.get(), MATCHING.get()));
+        f.butNotWhen(Arrays.asList(MATCHING, MATCHING));
         assertThat(f.test(mock(Wrapper.class))).isFalse();
     }
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/NegatingConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/NegatingConditionTest.java
@@ -22,12 +22,19 @@ import com.github.robozonky.strategy.natural.Wrapper;
 import com.github.robozonky.test.mock.MockLoanBuilder;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class NegatingConditionTest {
 
     private static final PortfolioOverview FOLIO = mock(PortfolioOverview.class);
+
+    @Test
+    void doubleNegation() {
+        final MarketplaceFilterCondition c = item -> true;
+        assertThat(c.negate().negate()).isSameAs(c);
+        assertThat(c.mayRequireRemoteRequests()).isFalse();
+    }
 
     @Test
     void negatingTrue() {

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/NeverAcceptingConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/NeverAcceptingConditionTest.java
@@ -26,6 +26,7 @@ class NeverAcceptingConditionTest {
     void negate() {
         final MarketplaceFilterCondition negated = NeverAceptingCondition.INSTANCE.negate();
         assertThat(negated).isEqualTo(AlwaysAcceptingCondition.INSTANCE);
+        assertThat(negated.mayRequireRemoteRequests()).isFalse();
     }
 
     @Test

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/ParticipationWrapperTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/ParticipationWrapperTest.java
@@ -16,6 +16,11 @@
 
 package com.github.robozonky.strategy.natural.conditions;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.function.Predicate;
+
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.Ratio;
 import com.github.robozonky.api.remote.entities.Loan;
@@ -30,11 +35,7 @@ import com.github.robozonky.strategy.natural.Wrapper;
 import com.github.robozonky.test.mock.MockLoanBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.*;
 
@@ -118,6 +119,6 @@ class ParticipationWrapperTest {
         when(p.getInterestRate()).thenReturn(Ratio.fromPercentage(15));
         final ParticipationDescriptor pd = new ParticipationDescriptor(p, () -> l);
         final Wrapper<ParticipationDescriptor> w = Wrapper.wrap(pd, FOLIO);
-        assertThat(f).rejects(w);
+        assertThat((Predicate<Wrapper<?>>) f).rejects(w);
     }
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/ShortStoryConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/ShortStoryConditionTest.java
@@ -40,4 +40,11 @@ class ShortStoryConditionTest {
         when(l.getStory()).thenReturn(story);
         assertThat(new ShortStoryCondition().test(l)).isTrue();
     }
+
+    @Test
+    void expectsRemoteRequest() {
+        final AbstractStoryCondition condition = new ShortStoryCondition();
+        assertThat(condition.mayRequireRemoteRequests()).isTrue();
+    }
+
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/VeryShortStoryConditionTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/conditions/VeryShortStoryConditionTest.java
@@ -40,4 +40,11 @@ class VeryShortStoryConditionTest {
         when(l.getStory()).thenReturn(story);
         assertThat(new VeryShortStoryCondition().test(l)).isTrue();
     }
+
+    @Test
+    void expectsRemoteRequest() {
+        final AbstractStoryCondition condition = new VeryShortStoryCondition();
+        assertThat(condition.mayRequireRemoteRequests()).isTrue();
+    }
+
 }


### PR DESCRIPTION
Some filters require additional HTTP requests. But these may not be necessary, if a loan is first filtered out by a filter which can work without remote requests. Therefore, we prioritize these fast filters.