### PR TITLE
Refactor how we specify investment amounts

### DIFF
--- a/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
@@ -22,7 +22,7 @@ primaryExpression returns [ParsedStrategy result] :
             final DefaultValues v = new DefaultValues($s.result);
             // enable primary and secondary marketplaces, disable selling, do not enable reservation system
             final FilterSupplier f = new FilterSupplier(v, Collections.emptySet(), Collections.emptySet());
-            $result = new ParsedStrategy(v, Collections.emptySet(), Collections.emptyMap(), f); })
+            $result = new ParsedStrategy(v, f); })
         | ( c=complexExpression { $result = $c.result; })
     ) {
         // only set version when the optional expression was actually present

--- a/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
@@ -41,6 +41,7 @@ complexExpression returns [ParsedStrategy result]
     @init {
         Collection<PortfolioShare> portfolioStructures = Collections.emptyList();
         Map<Rating, InvestmentSize> investmentSizes = Collections.emptyMap();
+        Map<Rating, InvestmentSize> purchaseSizes = Collections.emptyMap();
         Collection<MarketplaceFilter> primaryFilters = Collections.emptyList();
         Collection<MarketplaceFilter> secondaryFilters = Collections.emptyList();
         Collection<MarketplaceFilter> sellFilters = Collections.emptyList();
@@ -56,9 +57,23 @@ complexExpression returns [ParsedStrategy result]
     )?
 
     (
-        DELIM 'Výše investice'
-        i=investmentSizeExpression
-        { investmentSizes = $i.result; }
+        (
+            DELIM 'Výše investice'
+            i1=legacyInvestmentSizeExpression
+            { investmentSizes = $i1.result; }
+        ) | (
+            (
+                DELIM 'Výše investice'
+                i2=investmentSizeExpression
+                { investmentSizes = $i2.result; }
+            )
+            (
+                DELIM 'Výše nákupu'
+                i3=purchaseSizeExpression
+                { purchaseSizes = $i3.result; }
+            )?
+
+        )
     )?
 
     (
@@ -102,7 +117,7 @@ complexExpression returns [ParsedStrategy result]
     )
 
     {
-        $result = new ParsedStrategy(v, portfolioStructures, investmentSizes,
+        $result = new ParsedStrategy(v, portfolioStructures, investmentSizes, purchaseSizes,
                                      new FilterSupplier(v, primaryFilters, secondaryFilters, sellFilters));
     }
 ;

--- a/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
@@ -89,14 +89,15 @@ complexExpression returns [ParsedStrategy result]
                 sellFilters = $s.result;
             }
         ) | (
+             'Prodávat všechny participace bez poplatku a slevy, které odpovídají filtrům tržiště.' {
+                 v.setSellingMode(SellingMode.FREE_UNDISCOUNTED_AND_OUTSIDE_STRATEGY);
+             }
+         ) | (
             'Prodávat všechny participace bez poplatku, které odpovídají filtrům tržiště.' {
                 v.setSellingMode(SellingMode.FREE_AND_OUTSIDE_STRATEGY);
-                sellFilters = Collections.emptySet();
             }
         ) | (
-            'Prodej participací zakázán.' {
-                sellFilters = Collections.emptySet();
-            }
+            'Prodej participací zakázán.'
         )
     )
 

--- a/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/com/github/robozonky/strategy/natural/NaturalLanguageStrategy.g4
@@ -40,8 +40,8 @@ minimumVersionExpression returns [RoboZonkyVersion result] :
 complexExpression returns [ParsedStrategy result]
     @init {
         Collection<PortfolioShare> portfolioStructures = Collections.emptyList();
-        Map<Rating, InvestmentSize> investmentSizes = Collections.emptyMap();
-        Map<Rating, InvestmentSize> purchaseSizes = Collections.emptyMap();
+        Map<Rating, MoneyRange> investmentSizes = Collections.emptyMap();
+        Map<Rating, MoneyRange> purchaseSizes = Collections.emptyMap();
         Collection<MarketplaceFilter> primaryFilters = Collections.emptyList();
         Collection<MarketplaceFilter> secondaryFilters = Collections.emptyList();
         Collection<MarketplaceFilter> sellFilters = Collections.emptyList();

--- a/robozonky-strategy-natural/src/main/antlr4/imports/Defaults.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/Defaults.g4
@@ -13,7 +13,14 @@ defaultExpression returns [DefaultValues result]:
  (v=reservationExpression { $result.setReservationMode($v.result); })
  (e=exitDateExpression { $result.setExitProperties($e.result); })?
  (p=targetPortfolioSizeExpression { $result.setTargetPortfolioSize($p.result); })?
- (d=defaultInvestmentSizeExpression { $result.setInvestmentSize($d.result); })?
+ (
+    (
+        (d=legacyDefaultInvestmentSizeExpression { $result.setInvestmentSize($d.result); })
+    ) | (
+        i=defaultInvestmentSizeExpression { $result.setInvestmentSize($i.result); }
+        (b=defaultPurchaseSizeExpression { $result.setPurchaseSize($b.result); })?
+    )
+ )?
  (s=defaultInvestmentShareExpression { $result.setInvestmentShare($s.result); })?
 ;
 
@@ -37,10 +44,18 @@ exitDateExpression returns [ExitProperties result]:
     ) DOT
 ;
 
-defaultInvestmentSizeExpression returns [InvestmentSize result] :
+legacyDefaultInvestmentSizeExpression returns [InvestmentSize result] :
     'Běžná výše investice je ' i=investmentSizeRatingSubExpression {
          $result = $i.result;
     }
+;
+
+defaultInvestmentSizeExpression returns [int result] :
+    'Investovat po ' amount=intExpr KC '.' { $result = $amount.result; }
+;
+
+defaultPurchaseSizeExpression returns [int result] :
+    'Nakupovat nejvýše za ' amount=intExpr KC '.' { $result = $amount.result; }
 ;
 
 defaultInvestmentShareExpression returns [DefaultInvestmentShare result] :

--- a/robozonky-strategy-natural/src/main/antlr4/imports/Defaults.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/Defaults.g4
@@ -44,7 +44,7 @@ exitDateExpression returns [ExitProperties result]:
     ) DOT
 ;
 
-legacyDefaultInvestmentSizeExpression returns [InvestmentSize result] :
+legacyDefaultInvestmentSizeExpression returns [MoneyRange result] :
     'Běžná výše investice je ' i=investmentSizeRatingSubExpression {
          $result = $i.result;
     }

--- a/robozonky-strategy-natural/src/main/antlr4/imports/InvestmentSize.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/InvestmentSize.g4
@@ -8,6 +8,22 @@ import Tokens;
     import com.github.robozonky.strategy.natural.*;
 }
 
+legacyInvestmentSizeExpression returns [Map<Rating, InvestmentSize> result]:
+    {
+        final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
+    }
+    (i=legacyInvestmentSizeInterestRateExpression { result.put($i.rating, $i.size); })+ {
+        $result = result;
+    }
+;
+
+legacyInvestmentSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
+    'S úročením ' r=interestRateBasedRatingExpression 'jednotlivě investovat ' i=investmentSizeRatingSubExpression {
+        $rating = $r.result;
+        $size = $i.result;
+    }
+;
+
 investmentSizeExpression returns [Map<Rating, InvestmentSize> result]:
     {
         final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
@@ -18,8 +34,24 @@ investmentSizeExpression returns [Map<Rating, InvestmentSize> result]:
 ;
 
 investmentSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
-    'S úročením ' r=interestRateBasedRatingExpression 'jednotlivě investovat ' i=investmentSizeRatingSubExpression {
+    'S úročením ' r=interestRateBasedRatingExpression 'investovat po ' i=intExpr KC DOT {
         $rating = $r.result;
-        $size = $i.result;
+        $size = new InvestmentSize($i.result, $i.result);
+    }
+;
+
+purchaseSizeExpression returns [Map<Rating, InvestmentSize> result]:
+    {
+        final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
+    }
+    (i=purchaseSizeInterestRateExpression { result.put($i.rating, $i.size); })+ {
+        $result = result;
+    }
+;
+
+purchaseSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
+    'S úročením ' r=interestRateBasedRatingExpression 'nakupovat nejvýše za ' i=intExpr KC DOT {
+        $rating = $r.result;
+        $size = new InvestmentSize($i.result);
     }
 ;

--- a/robozonky-strategy-natural/src/main/antlr4/imports/InvestmentSize.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/InvestmentSize.g4
@@ -8,50 +8,50 @@ import Tokens;
     import com.github.robozonky.strategy.natural.*;
 }
 
-legacyInvestmentSizeExpression returns [Map<Rating, InvestmentSize> result]:
+legacyInvestmentSizeExpression returns [Map<Rating, MoneyRange> result]:
     {
-        final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
+        final EnumMap<Rating, MoneyRange> result = new EnumMap<>(Rating.class);
     }
     (i=legacyInvestmentSizeInterestRateExpression { result.put($i.rating, $i.size); })+ {
         $result = result;
     }
 ;
 
-legacyInvestmentSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
+legacyInvestmentSizeInterestRateExpression returns [Rating rating, MoneyRange size] :
     'S úročením ' r=interestRateBasedRatingExpression 'jednotlivě investovat ' i=investmentSizeRatingSubExpression {
         $rating = $r.result;
         $size = $i.result;
     }
 ;
 
-investmentSizeExpression returns [Map<Rating, InvestmentSize> result]:
+investmentSizeExpression returns [Map<Rating, MoneyRange> result]:
     {
-        final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
+        final EnumMap<Rating, MoneyRange> result = new EnumMap<>(Rating.class);
     }
     (i=investmentSizeInterestRateExpression { result.put($i.rating, $i.size); })+ {
         $result = result;
     }
 ;
 
-investmentSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
+investmentSizeInterestRateExpression returns [Rating rating, MoneyRange size] :
     'S úročením ' r=interestRateBasedRatingExpression 'investovat po ' i=intExpr KC DOT {
         $rating = $r.result;
-        $size = new InvestmentSize($i.result, $i.result);
+        $size = new MoneyRange($i.result, $i.result);
     }
 ;
 
-purchaseSizeExpression returns [Map<Rating, InvestmentSize> result]:
+purchaseSizeExpression returns [Map<Rating, MoneyRange> result]:
     {
-        final EnumMap<Rating, InvestmentSize> result = new EnumMap<>(Rating.class);
+        final EnumMap<Rating, MoneyRange> result = new EnumMap<>(Rating.class);
     }
     (i=purchaseSizeInterestRateExpression { result.put($i.rating, $i.size); })+ {
         $result = result;
     }
 ;
 
-purchaseSizeInterestRateExpression returns [Rating rating, InvestmentSize size] :
+purchaseSizeInterestRateExpression returns [Rating rating, MoneyRange size] :
     'S úročením ' r=interestRateBasedRatingExpression 'nakupovat nejvýše za ' i=intExpr KC DOT {
         $rating = $r.result;
-        $size = new InvestmentSize($i.result);
+        $size = new MoneyRange($i.result);
     }
 ;

--- a/robozonky-strategy-natural/src/main/antlr4/imports/Tokens.g4
+++ b/robozonky-strategy-natural/src/main/antlr4/imports/Tokens.g4
@@ -77,14 +77,14 @@ interestRateBasedRatingExpression returns [Rating result] :
     r=floatExpr ' % p.a' DOT? { $result = Rating.findByCode($r.result.toString()); }
 ;
 
-investmentSizeRatingSubExpression returns [InvestmentSize result] :
+investmentSizeRatingSubExpression returns [MoneyRange result] :
     (
         (amount=intExpr
-            { $result = new InvestmentSize($amount.result, $amount.result); })
+            { $result = new MoneyRange($amount.result, $amount.result); })
         | ('až' max=intExpr
-            { $result = new InvestmentSize($max.result); })
+            { $result = new MoneyRange($max.result); })
         | (min=intExpr UP_TO max=intExpr
-            { $result = new InvestmentSize($min.result, $max.result); })
+            { $result = new MoneyRange($min.result, $max.result); })
     ) KC DOT
 ;
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package com.github.robozonky.strategy.natural;
 
+import java.time.Period;
+import java.util.Optional;
+
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.strategies.ReservationMode;
 import com.github.robozonky.internal.test.DateUtil;
-
-import java.time.Period;
-import java.util.Optional;
 
 class DefaultValues {
 
@@ -30,6 +30,7 @@ class DefaultValues {
     private SellingMode sellingMode = null;
     private Money targetPortfolioSize = Money.from(Long.MAX_VALUE);
     private InvestmentSize investmentSize = new InvestmentSize();
+    private InvestmentSize purchaseSize = new InvestmentSize();
     private DefaultInvestmentShare investmentShare = new DefaultInvestmentShare();
     private ExitProperties exitProperties;
 
@@ -106,6 +107,20 @@ class DefaultValues {
             throw new IllegalArgumentException("Default investment size must be provided.");
         }
         this.investmentSize = investmentSize;
+    }
+
+    public void setInvestmentSize(final int investmentSize) {
+        if (investmentSize % 200 != 0) {
+            throw new IllegalArgumentException("Investment size must be divisible by 200: " + investmentSize);
+        }
+        this.investmentSize = new InvestmentSize(investmentSize, investmentSize);
+    }
+
+    public InvestmentSize getPurchaseSize() {
+        return purchaseSize;
+    }
+    public void setPurchaseSize(final int purchaseSize) {
+        this.purchaseSize = new InvestmentSize(purchaseSize);
     }
 
     @Override

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/DefaultValues.java
@@ -29,8 +29,8 @@ class DefaultValues {
     private ReservationMode reservationMode = null;
     private SellingMode sellingMode = null;
     private Money targetPortfolioSize = Money.from(Long.MAX_VALUE);
-    private InvestmentSize investmentSize = new InvestmentSize();
-    private InvestmentSize purchaseSize = new InvestmentSize();
+    private MoneyRange investmentSize = new MoneyRange();
+    private MoneyRange purchaseSize = new MoneyRange();
     private DefaultInvestmentShare investmentShare = new DefaultInvestmentShare();
     private ExitProperties exitProperties;
 
@@ -98,11 +98,11 @@ class DefaultValues {
         this.investmentShare = investmentShare;
     }
 
-    public InvestmentSize getInvestmentSize() {
+    public MoneyRange getInvestmentSize() {
         return investmentSize;
     }
 
-    public void setInvestmentSize(final InvestmentSize investmentSize) {
+    public void setInvestmentSize(final MoneyRange investmentSize) {
         if (investmentSize == null) {
             throw new IllegalArgumentException("Default investment size must be provided.");
         }
@@ -113,14 +113,14 @@ class DefaultValues {
         if (investmentSize % 200 != 0) {
             throw new IllegalArgumentException("Investment size must be divisible by 200: " + investmentSize);
         }
-        this.investmentSize = new InvestmentSize(investmentSize, investmentSize);
+        this.investmentSize = new MoneyRange(investmentSize, investmentSize);
     }
 
-    public InvestmentSize getPurchaseSize() {
+    public MoneyRange getPurchaseSize() {
         return purchaseSize;
     }
     public void setPurchaseSize(final int purchaseSize) {
-        this.purchaseSize = new InvestmentSize(purchaseSize);
+        this.purchaseSize = new MoneyRange(purchaseSize);
     }
 
     @Override

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/MoneyRange.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/MoneyRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,20 @@ package com.github.robozonky.strategy.natural;
 
 import com.github.robozonky.api.Money;
 
-class InvestmentSize {
+class MoneyRange {
 
     private final Money minimumInvestment;
     private final Money maximumInvestment;
 
-    public InvestmentSize() {
+    public MoneyRange() {
         this(20_000); // this is the theoretical maximum allowed by Zonky
     }
 
-    public InvestmentSize(final int maximumInvestmentInCzk) {
+    public MoneyRange(final int maximumInvestmentInCzk) {
         this(0, maximumInvestmentInCzk);
     }
 
-    public InvestmentSize(final int minimumInvestmentInCzk, final int maximumInvestmentInCzk) {
+    public MoneyRange(final int minimumInvestmentInCzk, final int maximumInvestmentInCzk) {
         this.minimumInvestment = Money.from(Math.min(minimumInvestmentInCzk, maximumInvestmentInCzk));
         this.maximumInvestment = Money.from(Math.max(minimumInvestmentInCzk, maximumInvestmentInCzk));
     }

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguagePurchaseStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/NaturalLanguagePurchaseStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ class NaturalLanguagePurchaseStrategy implements PurchaseStrategy {
 
     private Money[] getRecommendationBoundaries(final Participation participation) {
         final Rating rating = participation.getRating();
-        final Money minimumInvestment = strategy.getMinimumInvestmentSize(rating);
-        final Money maximumInvestment = strategy.getMaximumInvestmentSize(rating);
+        final Money minimumInvestment = strategy.getMinimumPurchaseSize(rating);
+        final Money maximumInvestment = strategy.getMaximumPurchaseSize(rating);
         return new Money[]{minimumInvestment, maximumInvestment};
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
@@ -40,8 +40,8 @@ class ParsedStrategy {
 
     private final DefaultValues defaults;
     private final Map<Rating, PortfolioShare> portfolio;
-    private final Map<Rating, InvestmentSize> investmentSizes;
-    private final Map<Rating, InvestmentSize> purchaseSizes;
+    private final Map<Rating, MoneyRange> investmentSizes;
+    private final Map<Rating, MoneyRange> purchaseSizes;
     private final FilterSupplier filters;
     private RoboZonkyVersion minimumVersion;
 
@@ -67,13 +67,13 @@ class ParsedStrategy {
     }
 
     ParsedStrategy(final DefaultValues defaults, final Collection<PortfolioShare> portfolio,
-                   final Map<Rating, InvestmentSize> investmentSizes, final Map<Rating, InvestmentSize> purchaseSizes) {
+                   final Map<Rating, MoneyRange> investmentSizes, final Map<Rating, MoneyRange> purchaseSizes) {
         this(defaults, portfolio, investmentSizes, purchaseSizes, new FilterSupplier(defaults));
     }
 
     public ParsedStrategy(final DefaultValues defaults, final Collection<PortfolioShare> portfolio,
-                          final Map<Rating, InvestmentSize> investmentSizes,
-                          final Map<Rating, InvestmentSize> purchaseSizes, final FilterSupplier filters) {
+                          final Map<Rating, MoneyRange> investmentSizes,
+                          final Map<Rating, MoneyRange> purchaseSizes, final FilterSupplier filters) {
         this.defaults = defaults;
         this.portfolio = portfolio.isEmpty() ? Collections.emptyMap() :
                 new EnumMap<>(portfolio.stream().
@@ -120,7 +120,7 @@ class ParsedStrategy {
         }
     }
 
-    private InvestmentSize getInvestmentSize(final Rating rating) {
+    private MoneyRange getInvestmentSize(final Rating rating) {
         return investmentSizes.getOrDefault(rating, defaults.getInvestmentSize());
     }
 
@@ -132,7 +132,7 @@ class ParsedStrategy {
         return getInvestmentSize(rating).getMaximumInvestment();
     }
 
-    private InvestmentSize getPurchaseSize(final Rating rating) {
+    private MoneyRange getPurchaseSize(final Rating rating) {
         return purchaseSizes.getOrDefault(rating, defaults.getPurchaseSize());
     }
 

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
@@ -59,8 +59,11 @@ class ParsedStrategy {
     }
 
     ParsedStrategy(final DefaultValues values, final Collection<MarketplaceFilter> filters) {
-        this(values, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
-             new FilterSupplier(values, filters));
+        this(values, new FilterSupplier(values, filters));
+    }
+
+    ParsedStrategy(final DefaultValues values, final FilterSupplier filters) {
+        this(values, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(), filters);
     }
 
     ParsedStrategy(final DefaultValues defaults, final Collection<PortfolioShare> portfolio,

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/ParsedStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ class ParsedStrategy {
     private final DefaultValues defaults;
     private final Map<Rating, PortfolioShare> portfolio;
     private final Map<Rating, InvestmentSize> investmentSizes;
+    private final Map<Rating, InvestmentSize> purchaseSizes;
     private final FilterSupplier filters;
     private RoboZonkyVersion minimumVersion;
 
@@ -49,7 +50,8 @@ class ParsedStrategy {
     }
 
     ParsedStrategy(final DefaultValues values) {
-        this(values, Collections.emptySet(), Collections.emptyMap(), new FilterSupplier(values));
+        this(values, Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap(),
+             new FilterSupplier(values));
     }
 
     ParsedStrategy(final DefaultPortfolio portfolio, final Collection<MarketplaceFilter> filters) {
@@ -57,21 +59,24 @@ class ParsedStrategy {
     }
 
     ParsedStrategy(final DefaultValues values, final Collection<MarketplaceFilter> filters) {
-        this(values, Collections.emptyList(), Collections.emptyMap(), new FilterSupplier(values, filters));
+        this(values, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(),
+             new FilterSupplier(values, filters));
     }
 
     ParsedStrategy(final DefaultValues defaults, final Collection<PortfolioShare> portfolio,
-                   final Map<Rating, InvestmentSize> investmentSizes) {
-        this(defaults, portfolio, investmentSizes, new FilterSupplier(defaults));
+                   final Map<Rating, InvestmentSize> investmentSizes, final Map<Rating, InvestmentSize> purchaseSizes) {
+        this(defaults, portfolio, investmentSizes, purchaseSizes, new FilterSupplier(defaults));
     }
 
     public ParsedStrategy(final DefaultValues defaults, final Collection<PortfolioShare> portfolio,
-                          final Map<Rating, InvestmentSize> investmentSizes, final FilterSupplier filters) {
+                          final Map<Rating, InvestmentSize> investmentSizes,
+                          final Map<Rating, InvestmentSize> purchaseSizes, final FilterSupplier filters) {
         this.defaults = defaults;
         this.portfolio = portfolio.isEmpty() ? Collections.emptyMap() :
                 new EnumMap<>(portfolio.stream().
                         collect(Collectors.toMap(PortfolioShare::getRating, Function.identity())));
         this.investmentSizes = investmentSizes.isEmpty() ? Collections.emptyMap() : new EnumMap<>(investmentSizes);
+        this.purchaseSizes = purchaseSizes.isEmpty() ? Collections.emptyMap() : new EnumMap<>(purchaseSizes);
         this.filters = filters;
     }
 
@@ -122,6 +127,18 @@ class ParsedStrategy {
 
     public Money getMaximumInvestmentSize(final Rating rating) {
         return getInvestmentSize(rating).getMaximumInvestment();
+    }
+
+    private InvestmentSize getPurchaseSize(final Rating rating) {
+        return purchaseSizes.getOrDefault(rating, defaults.getPurchaseSize());
+    }
+
+    public Money getMinimumPurchaseSize(final Rating rating) {
+        return getPurchaseSize(rating).getMinimumInvestment();
+    }
+
+    public Money getMaximumPurchaseSize(final Rating rating) {
+        return getPurchaseSize(rating).getMaximumInvestment();
     }
 
     private <T> Stream<T> getApplicable(final Stream<Wrapper<T>> wrappers, final String type) {
@@ -193,6 +210,7 @@ class ParsedStrategy {
         return "ParsedStrategy{" +
                 "defaults=" + defaults +
                 ", investmentSizes=" + investmentSizes +
+                ", purchaseSizes=" + purchaseSizes +
                 ", minimumVersion=" + minimumVersion +
                 ", portfolio=" + portfolio +
                 ", filters=" + filters +

--- a/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/SellingMode.java
+++ b/robozonky-strategy-natural/src/main/java/com/github/robozonky/strategy/natural/SellingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,5 +19,6 @@ package com.github.robozonky.strategy.natural;
 public enum SellingMode {
 
     SELL_FILTERS,
-    FREE_AND_OUTSIDE_STRATEGY
+    FREE_AND_OUTSIDE_STRATEGY,
+    FREE_UNDISCOUNTED_AND_OUTSIDE_STRATEGY
 }

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeRecommenderTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeRecommenderTest.java
@@ -45,7 +45,7 @@ class InvestmentSizeRecommenderTest {
         // no filters, as the SUT doesn't do filtering; no portfolio, as that is not used either
         final DefaultValues defaults = new DefaultValues(DefaultPortfolio.EMPTY);
         defaults.setInvestmentShare(new DefaultInvestmentShare(MAXIMUM_SHARE));
-        final InvestmentSize target = new InvestmentSize(MAXIMUM_INVESTMENT);
+        final MoneyRange target = new MoneyRange(MAXIMUM_INVESTMENT);
         return new ParsedStrategy(defaults, Collections.emptyList(),
                                   Collections.singletonMap(mockLoan(0).getRating(), target),
                                   Collections.emptyMap());

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeRecommenderTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeRecommenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package com.github.robozonky.strategy.natural;
 
+import java.util.Collections;
+
 import com.github.robozonky.api.Money;
 import com.github.robozonky.api.remote.entities.Loan;
 import com.github.robozonky.api.remote.entities.Restrictions;
@@ -23,9 +25,7 @@ import com.github.robozonky.api.remote.enums.Rating;
 import com.github.robozonky.test.mock.MockLoanBuilder;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class InvestmentSizeRecommenderTest {
@@ -47,7 +47,8 @@ class InvestmentSizeRecommenderTest {
         defaults.setInvestmentShare(new DefaultInvestmentShare(MAXIMUM_SHARE));
         final InvestmentSize target = new InvestmentSize(MAXIMUM_INVESTMENT);
         return new ParsedStrategy(defaults, Collections.emptyList(),
-                                  Collections.singletonMap(mockLoan(0).getRating(), target));
+                                  Collections.singletonMap(mockLoan(0).getRating(), target),
+                                  Collections.emptyMap());
     }
 
     @Test

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/InvestmentSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ class InvestmentSizeTest {
 
     @Test
     void regular() {
-        final InvestmentSize s = new InvestmentSize(InvestmentSizeTest.MIN, InvestmentSizeTest.MAX);
+        final MoneyRange s = new MoneyRange(InvestmentSizeTest.MIN, InvestmentSizeTest.MAX);
         assertSoftly(softly -> {
             softly.assertThat(s.getMinimumInvestment()).isEqualTo(Money.from(InvestmentSizeTest.MIN));
             softly.assertThat(s.getMaximumInvestment()).isEqualTo(Money.from(InvestmentSizeTest.MAX));
@@ -36,7 +36,7 @@ class InvestmentSizeTest {
 
     @Test
     void switched() {
-        final InvestmentSize s = new InvestmentSize(InvestmentSizeTest.MAX, InvestmentSizeTest.MIN);
+        final MoneyRange s = new MoneyRange(InvestmentSizeTest.MAX, InvestmentSizeTest.MIN);
         assertSoftly(softly -> {
             softly.assertThat(s.getMinimumInvestment()).isEqualTo(Money.from(InvestmentSizeTest.MIN));
             softly.assertThat(s.getMaximumInvestment()).isEqualTo(Money.from(InvestmentSizeTest.MAX));
@@ -45,7 +45,7 @@ class InvestmentSizeTest {
 
     @Test
     void omitted() {
-        final InvestmentSize s = new InvestmentSize(InvestmentSizeTest.MAX);
+        final MoneyRange s = new MoneyRange(InvestmentSizeTest.MAX);
         assertSoftly(softly -> {
             softly.assertThat(s.getMinimumInvestment()).isEqualTo(Money.ZERO);
             softly.assertThat(s.getMaximumInvestment()).isEqualTo(Money.from(InvestmentSizeTest.MAX));

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageInvestmentStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageInvestmentStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class NaturalLanguageInvestmentStrategyTest {
     void unacceptablePortfolioDueToOverInvestment() {
         final DefaultValues v = new DefaultValues(DefaultPortfolio.EMPTY);
         v.setTargetPortfolioSize(1000);
-        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap());
+        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap());
         final InvestmentStrategy s = new NaturalLanguageInvestmentStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);
         when(portfolio.getInvested()).thenReturn(p.getMaximumInvestmentSize());

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguagePurchaseStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguagePurchaseStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,8 @@ class NaturalLanguagePurchaseStrategyTest {
         final MarketplaceFilter filter = MarketplaceFilter.of(MarketplaceFilterCondition.alwaysAccepting());
         final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
         final FilterSupplier w = new FilterSupplier(v, Collections.emptySet(), Collections.singleton(filter));
-        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptySet(), Collections.emptyMap(), w);
+        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptySet(), Collections.emptyMap(),
+                                                    Collections.emptyMap(), w);
         final PurchaseStrategy s = new NaturalLanguagePurchaseStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);
         when(portfolio.getShareOnInvestment(any())).thenReturn(Ratio.ZERO);
@@ -104,6 +105,7 @@ class NaturalLanguagePurchaseStrategyTest {
     void recommendationIsMade() {
         final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
         final ParsedStrategy p = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap(),
+                                                    Collections.emptyMap(),
                                                     new FilterSupplier(v, null, Collections.emptySet()));
         final PurchaseStrategy s = new NaturalLanguagePurchaseStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageReservationStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageReservationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,8 @@ class NaturalLanguageReservationStrategyTest {
     void unacceptablePortfolioDueToOverInvestment() {
         final DefaultValues v = new DefaultValues(DefaultPortfolio.EMPTY);
         v.setTargetPortfolioSize(1000);
-        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap());
+        final ParsedStrategy p = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap(),
+                                                    Collections.emptyMap());
         final ReservationStrategy s = new NaturalLanguageReservationStrategy(p);
         final PortfolioOverview portfolio = mock(PortfolioOverview.class);
         when(portfolio.getInvested()).thenReturn(p.getMaximumInvestmentSize());

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageStrategyServiceTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/NaturalLanguageStrategyServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,12 @@
 
 package com.github.robozonky.strategy.natural;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
 import com.github.robozonky.api.strategies.StrategyService;
 import com.github.robozonky.internal.Defaults;
 import com.github.robozonky.internal.util.StringUtil;
@@ -23,13 +29,7 @@ import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
@@ -40,6 +40,7 @@ class NaturalLanguageStrategyServiceTest {
     private static Stream<DynamicTest> forType(final Type type) {
         return Stream.of(
                 dynamicTest("simplest possible", () -> simplest(type)),
+                dynamicTest("complex with legacy sizes", () -> complexLegacy(type)),
                 dynamicTest("complex", () -> complex(type)),
                 dynamicTest("with disabled filters", () -> disabled(type)),
                 dynamicTest("with enabled filters", () -> enabled(type)),
@@ -99,6 +100,13 @@ class NaturalLanguageStrategyServiceTest {
 
     private static void complex(final Type strategy) {
         final InputStream s = NaturalLanguageStrategyServiceTest.class.getResourceAsStream("complex");
+        final String str = StringUtil.toString(s, Defaults.CHARSET);
+        final Optional<?> actualStrategy = getStrategy(strategy, str);
+        assertThat(actualStrategy).isPresent();
+    }
+
+    private static void complexLegacy(final Type strategy) {
+        final InputStream s = NaturalLanguageStrategyServiceTest.class.getResourceAsStream("complex-legacy");
         final String str = StringUtil.toString(s, Defaults.CHARSET);
         final Optional<?> actualStrategy = getStrategy(strategy, str);
         assertThat(actualStrategy).isPresent();

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ class ParsedStrategyTest {
         final DefaultValues values = new DefaultValues(portfolio);
         values.setExitProperties(new ExitProperties(LocalDate.now().plusMonths(6))); // exit active, no sell-off yet
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.emptyList(), Collections.emptyMap(),
+                                                           Collections.emptyMap(),
                                                            new FilterSupplier(values, Collections.emptySet(),
                                                                               Collections.emptySet(),
                                                                               Collections.emptySet()));
@@ -144,7 +145,7 @@ class ParsedStrategyTest {
         final DefaultValues values = new DefaultValues(portfolio);
         final PortfolioShare share = new PortfolioShare(Rating.D, Ratio.fromPercentage(50), Ratio.fromPercentage(100));
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.singleton(share),
-                                                           Collections.emptyMap());
+                                                           Collections.emptyMap(), Collections.emptyMap());
         assertThat(strategy.getPermittedShare(Rating.D)).isEqualTo(Ratio.ONE);
     }
 
@@ -154,10 +155,24 @@ class ParsedStrategyTest {
         final DefaultValues values = new DefaultValues(portfolio);
         final InvestmentSize size = new InvestmentSize(600, 1000);
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.emptyList(),
-                                                           Collections.singletonMap(Rating.D, size));
+                                                           Collections.singletonMap(Rating.D, size),
+                                                           Collections.emptyMap());
         assertSoftly(softly -> {
             softly.assertThat(strategy.getMinimumInvestmentSize(Rating.D)).isEqualTo(Money.from(600));
             softly.assertThat(strategy.getMaximumInvestmentSize(Rating.D)).isEqualTo(Money.from(1_000));
+        });
+    }
+
+    @Test
+    void purchaseSizes() {
+        final DefaultPortfolio portfolio = DefaultPortfolio.EMPTY;
+        final DefaultValues values = new DefaultValues(portfolio);
+        final InvestmentSize size = new InvestmentSize(1000);
+        final ParsedStrategy strategy = new ParsedStrategy(values, Collections.emptyList(), Collections.emptyMap(),
+                                                           Collections.singletonMap(Rating.D, size));
+        assertSoftly(softly -> {
+            softly.assertThat(strategy.getMinimumPurchaseSize(Rating.D)).isEqualTo(Money.from(0));
+            softly.assertThat(strategy.getMaximumPurchaseSize(Rating.D)).isEqualTo(Money.from(1_000));
         });
     }
 
@@ -167,7 +182,8 @@ class ParsedStrategyTest {
         final Collection<MarketplaceFilter> filters = Collections.singleton(accepting);
         final DefaultValues v = new DefaultValues(DefaultPortfolio.PROGRESSIVE);
         final FilterSupplier s = new FilterSupplier(v, Collections.emptySet(), Collections.emptySet(), filters);
-        final ParsedStrategy ps = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap(), s);
+        final ParsedStrategy ps = new ParsedStrategy(v, Collections.emptyList(), Collections.emptyMap(),
+                                                     Collections.emptyMap(), s);
         final Loan l = ParsedStrategyTest.mockLoan(200_000);
         final LoanDescriptor ld = new LoanDescriptor(l);
         assertThat(ps.getApplicableLoans(Stream.of(ld), FOLIO)).isEmpty();

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/ParsedStrategyTest.java
@@ -153,7 +153,7 @@ class ParsedStrategyTest {
     void investmentSizes() {
         final DefaultPortfolio portfolio = DefaultPortfolio.EMPTY;
         final DefaultValues values = new DefaultValues(portfolio);
-        final InvestmentSize size = new InvestmentSize(600, 1000);
+        final MoneyRange size = new MoneyRange(600, 1000);
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.emptyList(),
                                                            Collections.singletonMap(Rating.D, size),
                                                            Collections.emptyMap());
@@ -167,7 +167,7 @@ class ParsedStrategyTest {
     void purchaseSizes() {
         final DefaultPortfolio portfolio = DefaultPortfolio.EMPTY;
         final DefaultValues values = new DefaultValues(portfolio);
-        final InvestmentSize size = new InvestmentSize(1000);
+        final MoneyRange size = new MoneyRange(1000);
         final ParsedStrategy strategy = new ParsedStrategy(values, Collections.emptyList(), Collections.emptyMap(),
                                                            Collections.singletonMap(Rating.D, size));
         assertSoftly(softly -> {

--- a/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/UtilTest.java
+++ b/robozonky-strategy-natural/src/test/java/com/github/robozonky/strategy/natural/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ class UtilTest extends AbstractRoboZonkyTest {
                         new PortfolioShare(Rating.A, fromPercentage(targetShareA)),
                         new PortfolioShare(Rating.B, fromPercentage(targetShareB)),
                         new PortfolioShare(Rating.C, fromPercentage(targetShareC))
-                ), Collections.emptyMap());
+                ), Collections.emptyMap(), Collections.emptyMap());
         // all ratings have zero share; C > B > A
         final Set<Rating> ratings = EnumSet.of(Rating.A, Rating.B, Rating.C);
         PortfolioOverview portfolio = preparePortfolio(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);

--- a/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/complex-legacy
+++ b/robozonky-strategy-natural/src/test/resources/com/github/robozonky/strategy/natural/complex-legacy
@@ -10,8 +10,7 @@ Robot má udržovat uživatelem definované portfolio.
 Robot má převzít kontrolu nad rezervačním systémem a přijímat rezervace půjček odpovídajících této strategii.
 Opustit Zonky k 31.12.2021, výprodej zahájit 12. 3. 2020.
 Cílová zůstatková částka je                                 100000 Kč.
-Investovat po                                               200 Kč.
-Nakupovat nejvýše za                                        1000 Kč.
+Běžná výše investice je                                     200 Kč.
 Investovat maximálně                                        1 % výše úvěru.
 
 # Volitelná sekce.
@@ -22,16 +21,11 @@ Prostředky úročené     13,49 % p.a. mají tvořit     5 až 10 % aktuální 
 Prostředky úročené     19,99 % p.a. mají tvořit     1 až  2 % aktuální zůstatkové částky.
 
 # Volitelná sekce.
-# Neuvedené ratingy budou investovány ve výchozí výši.
+# Neuvedené ratingy budou investovány v běžné výši.
 - Výše investice
-S úročením  3,99 % p.a. investovat po   600 Kč.
-S úročením 15,49 % p.a. investovat po  1000 Kč.
-
-# Volitelná sekce.
-# Neuvedené ratingy budou nakupovány ve výchozí výši.
-- Výše nákupu
-S úročením  6,99 % p.a. nakupovat nejvýše za   200 Kč.
-S úročením 10,99 % p.a. nakupovat nejvýše za  1100 Kč.
+S úročením  3,99 % p.a. jednotlivě investovat       až 600 Kč.
+S úročením 10,99 % p.a. jednotlivě investovat   800 až 400 Kč.
+S úročením 15,49 % p.a. jednotlivě investovat         1000 Kč.
 
 # Volitelná sekce.
 # Jednotlivé řádky představují vzájemně nezávislé filtry.
@@ -78,6 +72,7 @@ Ignorovat participaci, kde: délka přesahuje 36 měsíců.
 # Náhradou slova "úvěr" nebo "participaci" za "vše" se bude filtr vztahovat shodně na primární i sekundární trh.
 # Většina filtrů lze tedy napsat tak, aby platila zároveň pro primární i sekundární trh.
 Ignorovat vše, kde: délka přesahuje 36 měsíců.
+
 
 # Volitelná sekce.
 # Jednotlivé řádky představují vzájemně nezávislé filtry.


### PR DESCRIPTION
This also introduces support for custom purchase amounts, closing #422 and allows for a setting to only sell when the investment is both free and non-discounted.