### PR TITLE
Add status 400 description to notification

### DIFF
--- a/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/daemon-suspended.ftl
+++ b/robozonky-notifications/src/main/resources/com/github/robozonky/notifications/templates/html/daemon-suspended.ftl
@@ -8,6 +8,7 @@ Funkčnost robota bude obnovena hned, jak to bude možné. Následují detailní
 <ul>
     <li>"HTTP 500" a vyšší jsou interní chybou <@zonky /> serverů.</li>
     <li>"HTTP 429" značí, že robot narazil na časový limit dotazů na <@zonky /> a musí si dát pauzu.</li>
+    <li>"HTTP 400" může značit, že vypršel autoriační token do <@zonky />.</li>
 </ul>
 
 <p>V ostatních případech pravděpodobně došlo k chybě uvnitř <@robozonky />. Zvažte kontaktovat komunitu


### PR DESCRIPTION
To help user find the root cause of the error contained in the notification.