### PR TITLE
Read marketplaces incrementally (fixes #522)

### DIFF
--- a/robozonky-api/src/main/java/com/github/robozonky/internal/async/CachedThreadPoolBasedScheduler.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/async/CachedThreadPoolBasedScheduler.java
@@ -62,6 +62,11 @@ final class CachedThreadPoolBasedScheduler implements Scheduler {
     }
 
     @Override
+    public boolean isClosed() {
+        return executorService.isShutdown();
+    }
+
+    @Override
     public void close() throws Exception {
         executorService.shutdownNow();
         LOGGER.debug("Shutting down {}.", executorService);

--- a/robozonky-api/src/main/java/com/github/robozonky/internal/async/Scheduler.java
+++ b/robozonky-api/src/main/java/com/github/robozonky/internal/async/Scheduler.java
@@ -35,4 +35,6 @@ public interface Scheduler extends AutoCloseable {
     TaskDescriptor submit(final Runnable toSchedule, final Duration delayInBetween, final Duration firstDelay,
                           final Duration timeout);
 
+    boolean isClosed();
+
 }

--- a/robozonky-api/src/test/java/com/github/robozonky/internal/async/SchedulerTest.java
+++ b/robozonky-api/src/test/java/com/github/robozonky/internal/async/SchedulerTest.java
@@ -21,11 +21,15 @@ import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.*;
+
 class SchedulerTest {
 
     @Test
     void simple() throws Exception {
-        try (Scheduler scheduler = Scheduler.create()) {
+        Scheduler scheduler = Scheduler.create();
+        assertThat(scheduler.isClosed()).isFalse();
+        try (scheduler) {
             TaskDescriptor task = scheduler.submit(() -> {
                 // NOOP
             }, Duration.ofMillis(1), Duration.ofMillis(2), Duration.ofMillis(10));
@@ -35,6 +39,7 @@ class SchedulerTest {
                 }
             }, "Timed out while waiting for operation to complete.");
         }
+        assertThat(scheduler.isClosed()).isTrue();
     }
 
 }

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Daemon.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/Daemon.java
@@ -33,11 +33,16 @@ public class Daemon implements InvestmentMode {
     private static final Logger LOGGER = LogManager.getLogger(Daemon.class);
     private final PowerTenant tenant;
     private final Lifecycle lifecycle;
-    private final Scheduler scheduler = Scheduler.create();
+    private final Scheduler scheduler;
 
     public Daemon(final PowerTenant tenant, final Lifecycle lifecycle) {
+        this(tenant, lifecycle, Scheduler.create());
+    }
+
+    Daemon(final PowerTenant tenant, final Lifecycle lifecycle, Scheduler scheduler) {
         this.tenant = tenant;
         this.lifecycle = lifecycle;
+        this.scheduler = scheduler;
     }
 
     private void scheduleDaemons(final Scheduler executor) { // run investing and purchasing daemons

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The RoboZonky Project
+ * Copyright 2020 The RoboZonky Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.github.robozonky.app.daemon;
 
+import java.time.Duration;
 import java.util.Collection;
 
 /**
@@ -25,6 +26,8 @@ import java.util.Collection;
  * @param <T> Type of the entity coming from the marketplace.
  */
 interface MarketplaceAccessor<T> {
+
+    Duration getForcedMarketplaceCheckInterval();
 
     Collection<T> getMarketplace();
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
@@ -35,8 +35,9 @@ import org.apache.logging.log4j.Logger;
  */
 abstract class MarketplaceAccessor<T> {
 
-    protected Select makeIncremental(final Select originalFilter,
-                                     final AtomicReference<Instant> lastFullMarketplaceCheckReference) {
+    private final AtomicReference<Instant> lastFullMarketplaceCheckReference = new AtomicReference<>(Instant.EPOCH);
+
+    protected Select makeIncremental(final Select originalFilter) {
         Instant lastFullMarketplaceCheck = lastFullMarketplaceCheckReference.get();
         Instant now = DateUtil.now();
         if (lastFullMarketplaceCheck.plus(getForcedMarketplaceCheckInterval()).isBefore(now)) {

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/MarketplaceAccessor.java
@@ -37,21 +37,24 @@ abstract class MarketplaceAccessor<T> {
 
     private final AtomicReference<Instant> lastFullMarketplaceCheckReference = new AtomicReference<>(Instant.EPOCH);
 
-    protected Select makeIncremental(final Select originalFilter) {
+    protected Select getIncrementalFilter() {
         Instant lastFullMarketplaceCheck = lastFullMarketplaceCheckReference.get();
         Instant now = DateUtil.now();
         if (lastFullMarketplaceCheck.plus(getForcedMarketplaceCheckInterval()).isBefore(now)) {
             lastFullMarketplaceCheckReference.set(now);
             getLogger().debug("Running full marketplace check with timestamp of {}, previous was {}.", now,
                               lastFullMarketplaceCheck);
-            return originalFilter;
+            return getBaseFilter();
         } else {
-            var filter = originalFilter.greaterThanOrEquals("datePublished",
-                                                OffsetDateTime.ofInstant(lastFullMarketplaceCheck, Defaults.ZONE_ID));
+            var filter = getBaseFilter()
+                    .greaterThanOrEquals("datePublished",
+                                         OffsetDateTime.ofInstant(lastFullMarketplaceCheck, Defaults.ZONE_ID));
             getLogger().debug("Running incremental marketplace check, starting from {}.", lastFullMarketplaceCheck);
             return filter;
         }
     }
+
+    protected abstract Select getBaseFilter();
 
     public abstract Duration getForcedMarketplaceCheckInterval();
 

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -16,6 +16,7 @@
 
 package com.github.robozonky.app.daemon;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
@@ -30,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 
 final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescriptor> {
 
+    private static final Duration FULL_CHECK_INTERVAL = Duration.ofMinutes(1);
     private static final Logger LOGGER = Audit.investing();
     /**
      * Will make sure that the endpoint only loads loans that are on the marketplace, and not the entire history.
@@ -41,6 +43,11 @@ final class PrimaryMarketplaceAccessor implements MarketplaceAccessor<LoanDescri
     public PrimaryMarketplaceAccessor(final Tenant tenant, final UnaryOperator<LastPublishedLoan> stateAccessor) {
         this.tenant = tenant;
         this.stateAccessor = stateAccessor;
+    }
+
+    @Override
+    public Duration getForcedMarketplaceCheckInterval() {
+        return FULL_CHECK_INTERVAL;
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/PrimaryMarketplaceAccessor.java
@@ -17,10 +17,8 @@
 package com.github.robozonky.app.daemon;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -37,7 +35,6 @@ final class PrimaryMarketplaceAccessor extends MarketplaceAccessor<LoanDescripto
     private static final Logger LOGGER = Audit.investing();
     private final Tenant tenant;
     private final UnaryOperator<LastPublishedLoan> stateAccessor;
-    private final AtomicReference<Instant> lastFullMarketplaceCheckReference = new AtomicReference<>(Instant.EPOCH);
 
     public PrimaryMarketplaceAccessor(final Tenant tenant, final UnaryOperator<LastPublishedLoan> stateAccessor) {
         this.tenant = tenant;
@@ -52,7 +49,7 @@ final class PrimaryMarketplaceAccessor extends MarketplaceAccessor<LoanDescripto
     private Select getMarketplaceFilter() {
         // Will make sure that the endpoint only loads loans that are on the marketplace, and not the entire history.
         var filter = new Select().greaterThan("nonReservedRemainingInvestment", 0);
-        return makeIncremental(filter, lastFullMarketplaceCheckReference);
+        return makeIncremental(filter);
     }
 
     @Override

--- a/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
+++ b/robozonky-app/src/main/java/com/github/robozonky/app/daemon/SecondaryMarketplaceAccessor.java
@@ -17,10 +17,8 @@
 package com.github.robozonky.app.daemon;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -38,7 +36,6 @@ final class SecondaryMarketplaceAccessor extends MarketplaceAccessor<Participati
 
     private final PowerTenant tenant;
     private final UnaryOperator<LastPublishedParticipation> stateAccessor;
-    private final AtomicReference<Instant> lastFullMarketplaceCheckReference = new AtomicReference<>(Instant.EPOCH);
 
     public SecondaryMarketplaceAccessor(final PowerTenant tenant,
                                         final UnaryOperator<LastPublishedParticipation> stateAccessor) {
@@ -51,7 +48,7 @@ final class SecondaryMarketplaceAccessor extends MarketplaceAccessor<Participati
                 .equalsPlain("willNotExceedLoanInvestmentLimit", "true")
                 .greaterThanOrEquals("remainingPrincipal", 2) // Sometimes there's near-0 participations; ignore clutter.
                 .lessThanOrEquals("remainingPrincipal", tenant.getKnownBalanceUpperBound().getValue().longValue());
-        return makeIncremental(filter, lastFullMarketplaceCheckReference);
+        return makeIncremental(filter);
     }
 
     @Override

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/DaemonTest.java
@@ -26,6 +26,7 @@ import com.github.robozonky.app.AbstractZonkyLeveragingTest;
 import com.github.robozonky.app.ReturnCode;
 import com.github.robozonky.app.runtime.Lifecycle;
 import com.github.robozonky.app.tenant.PowerTenant;
+import com.github.robozonky.internal.async.Scheduler;
 import com.github.robozonky.internal.jobs.SimplePayload;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,8 @@ class DaemonTest extends AbstractZonkyLeveragingTest {
     void get() throws Exception {
         final PowerTenant a = mockTenant(harmlessZonky(), true);
         final ExecutorService e = Executors.newFixedThreadPool(1);
-        try (final Daemon d = spy(new Daemon(a, lifecycle))) {
+        final Scheduler s = Scheduler.create();
+        try (final Daemon d = spy(new Daemon(a, lifecycle, s))) {
             assertThat(d.getSessionInfo()).isSameAs(a.getSessionInfo());
             doNothing().when(d).submitWithTenant(any(), any(), any(), any(), any(), any());
             doNothing().when(d).submitTenantless(any(), any(), any(), any(), any(), any());
@@ -55,5 +57,6 @@ class DaemonTest extends AbstractZonkyLeveragingTest {
             e.shutdownNow();
         }
         verify(a).close();
+        assertThat(s.isClosed()).isTrue();
     }
 }

--- a/robozonky-app/src/test/java/com/github/robozonky/app/daemon/StrategyExecutorTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/daemon/StrategyExecutorTest.java
@@ -302,7 +302,6 @@ class StrategyExecutorTest extends AbstractZonkyLeveragingTest {
         when(d.isEnabled(any())).thenReturn(false);
         final StrategyExecutor<LoanDescriptor, InvestmentStrategy, Loan> e = new StrategyExecutor<>(tenant, d);
         assertThat(e.get()).isEmpty();
-        verify(d, never()).newMarketplaceAccessor(any());
         final List<Event> evt = getEventsRequested();
         assertThat(evt).isEmpty();
     }


### PR DESCRIPTION
Both primary and secondary marketplace are now only ever read in full every couple of minutes. Every other time, we use the incremental API, triggered when a new investment/participation is registered.