### PR TITLE
Only run delinquent checks and weekly summaries when enabled

### DIFF
--- a/robozonky-app/src/test/java/com/github/robozonky/app/delinquencies/DelinquencyNotificationPayloadTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/delinquencies/DelinquencyNotificationPayloadTest.java
@@ -49,7 +49,7 @@ class DelinquencyNotificationPayloadTest extends AbstractZonkyLeveragingTest {
     private final Zonky zonky = harmlessZonky();
     private final Tenant tenant = mockTenant(zonky);
     private final Registry r = new Registry(tenant);
-    private final DelinquencyNotificationPayload payload = new DelinquencyNotificationPayload(t -> r);
+    private final DelinquencyNotificationPayload payload = new DelinquencyNotificationPayload(t -> r, true);
 
     @Test
     void initializesWithoutTriggeringEvents() {

--- a/robozonky-app/src/test/java/com/github/robozonky/app/summaries/SummarizerTest.java
+++ b/robozonky-app/src/test/java/com/github/robozonky/app/summaries/SummarizerTest.java
@@ -33,7 +33,7 @@ class SummarizerTest extends AbstractZonkyLeveragingTest {
 
     @Test
     void basics() {
-        final Summarizer summarizer = new Summarizer();
+        final Summarizer summarizer = new Summarizer(true);
         summarizer.accept(tenant);
         assertThat(this.getEventsRequested())
             .first()


### PR DESCRIPTION
These make a lot of API calls, and the only reason is so that RoboZonky can send an e-mail notification with the processed data.
When those notifications are disabled, there is no need to run this and stress Zonky servers.