### PR TITLE
Bump bundled JRE to 15

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -24,6 +24,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.DEFAULT_JDK_VERSION }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Compile all modules without testing
         run: mvn --batch-mode clean install -DskipTests ${{ env.STABILIZING_PROPERTIES }}
       - name: Test all modules inc. JaCoCo
@@ -45,6 +52,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.DEFAULT_JDK_VERSION }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Compile all modules without testing
         run: mvn --batch-mode clean install -DskipTests ${{ env.STABILIZING_PROPERTIES }}
       - name: Run mutation coverage on a single module
@@ -66,5 +80,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.jvm }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Compile and test all modules, skipping mutation coverage
         run: mvn --batch-mode verify -Dpit.skip=true ${{ env.STABILIZING_PROPERTIES }}

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false # Always see all results on all platforms.
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        jvm: [11, 14]
+        jvm: [ 11, 15 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout from Github

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   COMPILE_TIME_JDK_VERSION: 11
-  RUNTIME_JDK_VERSION: 14
+  RUNTIME_JDK_VERSION: 15
   JLINK_SCRIPT_FILENAME: .github/workflows/jlink.sh
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.RUNTIME_JDK_VERSION }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build and test
         run: mvn install --batch-mode -Dpit.skip=true
   jlink:
@@ -50,6 +57,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.RUNTIME_JDK_VERSION }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Run the build
         run: mvn install --batch-mode -DskipTests
       - name: Determine RoboZonky version
@@ -102,6 +116,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.RUNTIME_JDK_VERSION }}
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Download Linux main app JRE
         uses: actions/download-artifact@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN ROBOZONKY_VERSION=$(mvn -q \
     && chmod +x $BINARY_DIRECTORY/robozonky.sh
 
 # ... then build a minimalistic Java runtime using jlink ...
-FROM adoptopenjdk/openjdk15:alpine AS jlink
+FROM azul/zulu-openjdk-alpine:15 AS jlink
 ENV WORKING_DIRECTORY=/tmp/robozonky
 COPY --from=scratch /tmp/robozonky $WORKING_DIRECTORY
 COPY . .
@@ -41,41 +41,8 @@ COPY --from=jlink /tmp/robozonky $INSTALL_DIRECTORY
 ENV JAVA_OPTS="$JAVA_OPTS \
     -Drobozonky.properties.file=$CONFIG_DIRECTORY/robozonky.properties \
     -Dlog4j.configurationFile=$CONFIG_DIRECTORY/log4j2.xml"
-# Copied from https://github.com/AdoptOpenJDK/openjdk-docker/blob/master/14/jre/alpine/Dockerfile.hotspot.releases.full
-RUN apk add --no-cache --virtual .build-deps curl binutils \
-    && GLIBC_VER="2.31-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/* \
-# Except for this one, which is necessary to start the container with podman.
-    && mkdir $WORKING_DIRECTORY \
 # And this is just for debugging purposes.
+RUN mkdir $WORKING_DIRECTORY \
     && ls -l -R $INSTALL_DIRECTORY
 WORKDIR $WORKING_DIRECTORY
 ENTRYPOINT $INSTALL_DIRECTORY/robozonky.sh @$CONFIG_DIRECTORY/robozonky.cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN ROBOZONKY_VERSION=$(mvn -q \
     && chmod +x $BINARY_DIRECTORY/robozonky.sh
 
 # ... then build a minimalistic Java runtime using jlink ...
-FROM adoptopenjdk/openjdk14:alpine AS jlink
+FROM adoptopenjdk/openjdk15:alpine AS jlink
 ENV WORKING_DIRECTORY=/tmp/robozonky
 COPY --from=scratch /tmp/robozonky $WORKING_DIRECTORY
 COPY . .

--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,6 @@
             </goals>
             <configuration>
               <skip>${com.github.robozonky.distribution}</skip>
-              <failOnWarnings>true</failOnWarnings>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Bumps everything to OpenJDK 15. 
Docker image switched to Azul OpenJDK, because they already have 15 and also because they don't require glibc on Alpine, possibly leading to even smaller images. 
Javadoc no longer fails on warnings, as 15 has some unwelcome changes there.
Finally, CI now caches Maven artifacts for build speedup.