### PR TITLE
Bump to OpenJDK 16

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false # Always see all results on all platforms.
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        jvm: [ 11, 15 ]
+        jvm: [ 11, 16 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout from Github

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   COMPILE_TIME_JDK_VERSION: 11
-  RUNTIME_JDK_VERSION: 15
+  RUNTIME_JDK_VERSION: 16
   JLINK_SCRIPT_FILENAME: .github/workflows/jlink.sh
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN ROBOZONKY_VERSION=$(mvn -q \
     && chmod +x $BINARY_DIRECTORY/robozonky.sh
 
 # ... then build a minimalistic Java runtime using jlink ...
-FROM azul/zulu-openjdk-alpine:15 AS jlink
+FROM azul/zulu-openjdk-alpine:16 AS jlink
 ENV WORKING_DIRECTORY=/tmp/robozonky
 COPY --from=scratch /tmp/robozonky $WORKING_DIRECTORY
 COPY . .


### PR DESCRIPTION
Merge after the following becomes green:

- [x] GHA builds.
- [ ] Docker builds.

Both will take a while, as Zulu usually takes a couple days to release the new JDK.